### PR TITLE
Uv badge addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-orange.svg?style=for-the-badge)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-00c0ff.svg?style=for-the-badge)](https://www.python.org/downloads/)
+[![uv](https://img.shields.io/badge/uv-FF8C00.svg?style=for-the-badge)](https://github.com/astral-sh/uv)
 [![pytest](https://img.shields.io/badge/pytest-95%25-00ff00.svg?style=for-the-badge)](https://github.com/pytest-dev/pytest)
 [![Type checking: Ty](https://img.shields.io/badge/checked%20with-ty-ffcc00.svg?style=for-the-badge)](https://github.com/pypa/ty)
 [![Code style: Ruff](https://img.shields.io/badge/code%20style-ruff-f5a623.svg?style=for-the-badge)](https://github.com/astral-sh/ruff)


### PR DESCRIPTION
Add a `uv` badge to `README.md` after the Python badge.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-1dfa321e-78f7-40fe-a01a-3d802a975b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1dfa321e-78f7-40fe-a01a-3d802a975b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

