### PR TITLE
Issue 17 investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ uv run uvicorn server:app --host 0.0.0.0 --port 8082
 
 5. Reload extensions.
 
-That's it! The Claude Code VSCode extension now uses NVIDIA NIM for free. To go back to Anthropic models just comment out the the added block and reload extensions.
+6. **If you see the login screen** ("How do you want to log in?"): Click **Anthropic Console**, then authorize. The extension will start working. You may be redirected to buy credits in the browser—ignore that; the extension already works.
+
+That's it! The Claude Code VSCode extension now uses NVIDIA NIM for free. To go back to Anthropic models just comment out the added block and reload extensions.
 
 ---
 


### PR DESCRIPTION
Add a bypass for the VS Code extension login screen to the README and fix a typo.

The VS Code extension prompts users to upgrade to Pro/Max accounts, and this PR documents a workaround found by the user to bypass this check, addressing Issue #17.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-ebbd882d-a511-4a1f-a45d-9581c195ca74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ebbd882d-a511-4a1f-a45d-9581c195ca74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

