### PR TITLE
Add configurable HTTP timeouts for provider API requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@ PROVIDER_TYPE=nvidia_nim
 PROVIDER_RATE_LIMIT=40
 PROVIDER_RATE_WINDOW=60
 
+# HTTP client timeouts (seconds) for provider API requests
+HTTP_READ_TIMEOUT=300
+HTTP_WRITE_TIMEOUT=10
+HTTP_CONNECT_TIMEOUT=2
+
 
 # All Claude model requests are mapped to this model
 MODEL="stepfun-ai/step-3.5-flash"

--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ Browse: [model.lmstudio.ai](https://model.lmstudio.ai)
 | `LM_STUDIO_BASE_URL` | LM Studio server URL | `http://localhost:1234/v1` |
 | `PROVIDER_RATE_LIMIT` | LLM API requests per window | `40` |
 | `PROVIDER_RATE_WINDOW` | Rate limit window (seconds) | `60` |
+| `HTTP_READ_TIMEOUT` | Read timeout for provider API requests (seconds) | `300` |
+| `HTTP_WRITE_TIMEOUT` | Write timeout for provider API requests (seconds) | `10` |
+| `HTTP_CONNECT_TIMEOUT` | Connect timeout for provider API requests (seconds) | `2` |
 | `FAST_PREFIX_DETECTION` | Enable fast prefix detection | `true` |
 | `ENABLE_NETWORK_PROBE_MOCK` | Enable network probe mock | `true` |
 | `ENABLE_TITLE_GENERATION_SKIP` | Skip title generation | `true` |

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -32,6 +32,9 @@ def get_provider() -> BaseProvider:
                 rate_limit=settings.provider_rate_limit,
                 rate_window=settings.provider_rate_window,
                 nim_settings=settings.nim,
+                http_read_timeout=settings.http_read_timeout,
+                http_write_timeout=settings.http_write_timeout,
+                http_connect_timeout=settings.http_connect_timeout,
             )
             _provider = NvidiaNimProvider(config)
             logger.info("Provider initialized: %s", settings.provider_type)
@@ -44,6 +47,9 @@ def get_provider() -> BaseProvider:
                 rate_limit=settings.provider_rate_limit,
                 rate_window=settings.provider_rate_window,
                 nim_settings=settings.nim,
+                http_read_timeout=settings.http_read_timeout,
+                http_write_timeout=settings.http_write_timeout,
+                http_connect_timeout=settings.http_connect_timeout,
             )
             _provider = OpenRouterProvider(config)
             logger.info("Provider initialized: %s", settings.provider_type)
@@ -56,6 +62,9 @@ def get_provider() -> BaseProvider:
                 rate_limit=settings.provider_rate_limit,
                 rate_window=settings.provider_rate_window,
                 nim_settings=settings.nim,
+                http_read_timeout=settings.http_read_timeout,
+                http_write_timeout=settings.http_write_timeout,
+                http_connect_timeout=settings.http_connect_timeout,
             )
             _provider = LMStudioProvider(config)
             logger.info("Provider initialized: %s", settings.provider_type)

--- a/config/settings.py
+++ b/config/settings.py
@@ -50,6 +50,17 @@ class Settings(BaseSettings):
         default=60, validation_alias="PROVIDER_RATE_WINDOW"
     )
 
+    # ==================== HTTP Client Timeouts ====================
+    http_read_timeout: float = Field(
+        default=300.0, validation_alias="HTTP_READ_TIMEOUT"
+    )
+    http_write_timeout: float = Field(
+        default=10.0, validation_alias="HTTP_WRITE_TIMEOUT"
+    )
+    http_connect_timeout: float = Field(
+        default=2.0, validation_alias="HTTP_CONNECT_TIMEOUT"
+    )
+
     # ==================== Fast Prefix Detection ====================
     fast_prefix_detection: bool = True
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -20,6 +20,9 @@ class ProviderConfig(BaseModel):
     rate_limit: Optional[int] = None
     rate_window: int = 60
     nim_settings: NimSettings = Field(default_factory=NimSettings)
+    http_read_timeout: float = 300.0
+    http_write_timeout: float = 10.0
+    http_connect_timeout: float = 2.0
 
 
 class BaseProvider(ABC):

--- a/providers/lmstudio/client.py
+++ b/providers/lmstudio/client.py
@@ -4,6 +4,7 @@ import json
 import uuid
 from typing import Any, AsyncIterator
 
+import httpx
 from loguru import logger
 from openai import AsyncOpenAI
 
@@ -39,7 +40,12 @@ class LMStudioProvider(BaseProvider):
             api_key=self._api_key,
             base_url=self._base_url,
             max_retries=0,
-            timeout=300.0,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
         )
 
     def _build_request_body(self, request: Any) -> dict:

--- a/providers/nvidia_nim/client.py
+++ b/providers/nvidia_nim/client.py
@@ -4,6 +4,7 @@ import json
 import uuid
 from typing import Any, AsyncIterator
 
+import httpx
 from loguru import logger
 from openai import AsyncOpenAI
 
@@ -38,7 +39,12 @@ class NvidiaNimProvider(BaseProvider):
             api_key=self._api_key,
             base_url=self._base_url,
             max_retries=0,
-            timeout=300.0,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
         )
 
     def _build_request_body(self, request: Any) -> dict:

--- a/providers/open_router/client.py
+++ b/providers/open_router/client.py
@@ -4,6 +4,7 @@ import json
 import uuid
 from typing import Any, AsyncIterator
 
+import httpx
 from loguru import logger
 from openai import AsyncOpenAI
 
@@ -39,7 +40,12 @@ class OpenRouterProvider(BaseProvider):
             api_key=self._api_key,
             base_url=self._base_url,
             max_retries=0,
-            timeout=300.0,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
         )
 
     def _build_request_body(self, request: Any) -> dict:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -81,6 +81,39 @@ class TestSettings:
         settings = Settings()
         assert settings.provider_rate_window == 30
 
+    def test_http_read_timeout_from_env(self, monkeypatch):
+        """HTTP_READ_TIMEOUT env var is loaded into settings."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("HTTP_READ_TIMEOUT", "600")
+        settings = Settings()
+        assert settings.http_read_timeout == 600.0
+
+    def test_http_write_timeout_from_env(self, monkeypatch):
+        """HTTP_WRITE_TIMEOUT env var is loaded into settings."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("HTTP_WRITE_TIMEOUT", "20")
+        settings = Settings()
+        assert settings.http_write_timeout == 20.0
+
+    def test_http_connect_timeout_from_env(self, monkeypatch):
+        """HTTP_CONNECT_TIMEOUT env var is loaded into settings."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("HTTP_CONNECT_TIMEOUT", "5")
+        settings = Settings()
+        assert settings.http_connect_timeout == 5.0
+
+    def test_http_timeouts_defaults(self):
+        """HTTP timeout defaults are set correctly."""
+        from config.settings import Settings
+
+        settings = Settings()
+        assert settings.http_read_timeout == 300.0
+        assert settings.http_write_timeout == 10.0
+        assert settings.http_connect_timeout == 2.0
+
 
 # --- NimSettings Validation Tests ---
 

--- a/tests/test_lmstudio.py
+++ b/tests/test_lmstudio.py
@@ -148,6 +148,24 @@ def test_init_with_empty_api_key():
         assert provider._api_key == "lm-studio"
 
 
+def test_init_uses_configurable_timeouts():
+    """Test that provider passes configurable read/write/connect timeouts to client."""
+    config = ProviderConfig(
+        api_key="lm-studio",
+        base_url="http://localhost:1234/v1",
+        http_read_timeout=600.0,
+        http_write_timeout=15.0,
+        http_connect_timeout=5.0,
+    )
+    with patch("providers.lmstudio.client.AsyncOpenAI") as mock_openai:
+        LMStudioProvider(config)
+        call_kwargs = mock_openai.call_args[1]
+        timeout = call_kwargs["timeout"]
+        assert timeout.read == 600.0
+        assert timeout.write == 15.0
+        assert timeout.connect == 5.0
+
+
 def test_build_request_body_no_extra_body(lmstudio_provider):
     """LM Studio request body does NOT include extra_body/reasoning."""
     req = MockRequest()

--- a/tests/test_nvidia_nim.py
+++ b/tests/test_nvidia_nim.py
@@ -61,6 +61,27 @@ async def test_init(provider_config):
 
 
 @pytest.mark.asyncio
+async def test_init_uses_configurable_timeouts():
+    """Test that provider passes configurable read/write/connect timeouts to client."""
+    from providers.base import ProviderConfig
+
+    config = ProviderConfig(
+        api_key="test_key",
+        base_url="https://test.api.nvidia.com/v1",
+        http_read_timeout=600.0,
+        http_write_timeout=15.0,
+        http_connect_timeout=5.0,
+    )
+    with patch("providers.nvidia_nim.client.AsyncOpenAI") as mock_openai:
+        NvidiaNimProvider(config)
+        call_kwargs = mock_openai.call_args[1]
+        timeout = call_kwargs["timeout"]
+        assert timeout.read == 600.0
+        assert timeout.write == 15.0
+        assert timeout.connect == 5.0
+
+
+@pytest.mark.asyncio
 async def test_build_request_body(nim_provider):
     """Test request body construction."""
     req = MockRequest()

--- a/tests/test_open_router.py
+++ b/tests/test_open_router.py
@@ -71,6 +71,24 @@ def test_init(open_router_config):
         mock_openai.assert_called_once()
 
 
+def test_init_uses_configurable_timeouts():
+    """Test that provider passes configurable read/write/connect timeouts to client."""
+    config = ProviderConfig(
+        api_key="test_openrouter_key",
+        base_url="https://openrouter.ai/api/v1",
+        http_read_timeout=600.0,
+        http_write_timeout=15.0,
+        http_connect_timeout=5.0,
+    )
+    with patch("providers.open_router.client.AsyncOpenAI") as mock_openai:
+        OpenRouterProvider(config)
+        call_kwargs = mock_openai.call_args[1]
+        timeout = call_kwargs["timeout"]
+        assert timeout.read == 600.0
+        assert timeout.write == 15.0
+        assert timeout.connect == 5.0
+
+
 def test_build_request_body_has_reasoning_extra(open_router_provider):
     """Request body has extra_body.reasoning.enabled for thinking models."""
     req = MockRequest()


### PR DESCRIPTION
Updated the README to include new timeout settings. Implemented these timeouts in the provider classes and added corresponding tests to ensure they are correctly passed to the client. Also included environment variable support for the new settings.