### PR TITLE
Claude API 403 error

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -2,6 +2,7 @@
 
 from typing import Optional
 
+from fastapi import HTTPException
 from loguru import logger
 
 from config.settings import Settings, get_settings as _get_settings, NVIDIA_NIM_BASE_URL
@@ -24,6 +25,17 @@ def get_provider() -> BaseProvider:
         settings = get_settings()
 
         if settings.provider_type == "nvidia_nim":
+            if (
+                not settings.nvidia_nim_api_key
+                or not settings.nvidia_nim_api_key.strip()
+            ):
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "NVIDIA_NIM_API_KEY is not set. Add it to your .env file. "
+                        "Get a key at https://build.nvidia.com/settings/api-keys"
+                    ),
+                )
             from providers.nvidia_nim import NvidiaNimProvider
 
             config = ProviderConfig(
@@ -38,6 +50,17 @@ def get_provider() -> BaseProvider:
             _provider = NvidiaNimProvider(config, nim_settings=settings.nim)
             logger.info("Provider initialized: %s", settings.provider_type)
         elif settings.provider_type == "open_router":
+            if (
+                not settings.open_router_api_key
+                or not settings.open_router_api_key.strip()
+            ):
+                raise HTTPException(
+                    status_code=503,
+                    detail=(
+                        "OPENROUTER_API_KEY is not set. Add it to your .env file. "
+                        "Get a key at https://openrouter.ai/keys"
+                    ),
+                )
             from providers.open_router import OpenRouterProvider
 
             config = ProviderConfig(


### PR DESCRIPTION
Add validation for missing API keys to provide clearer error messages instead of generic 403s.

This addresses GitHub issue #29, where users received an opaque "Header of type authorization was missing" error when `NVIDIA_NIM_API_KEY` or `OPENROUTER_API_KEY` was not configured. The new validation raises a `503 HTTPException` with a specific message guiding the user to set the correct environment variable.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-a0723055-e43f-4215-9f87-5b562f7b66cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0723055-e43f-4215-9f87-5b562f7b66cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

