### PR TITLE
Configure Ruff linter and formatter with project standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,3 +30,36 @@ dev = [
     "ty>=0.0.1",
     "ruff>=0.9.0",
 ]
+
+[tool.ruff]
+target-version = "py314"
+line-length = 88
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # Pyflakes (undefined names, unused imports)
+    "I",    # isort (import ordering)
+    "UP",   # pyupgrade (modernise syntax for target Python version)
+    "B",    # flake8-bugbear (common bugs and anti-patterns)
+    "C4",   # flake8-comprehensions (idiomatic comprehensions)
+    "SIM",  # flake8-simplify (simplifiable code patterns)
+    "PERF", # Perflint (performance anti-patterns)
+    "RUF",  # Ruff-specific rules
+]
+ignore = [
+    "E501", # line too long — enforced by the formatter instead
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["api", "cli", "config", "messaging", "providers", "utils"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"
+skip-magic-trailing-comma = false
+
+[tool.ty.environment]
+python-version = "3.14"


### PR DESCRIPTION
## Summary
This PR adds comprehensive Ruff configuration to the project, establishing consistent code quality and formatting standards across the codebase.

## Key Changes
- **Ruff linter configuration**: Enabled 10 rule categories including pycodestyle, Pyflakes, isort, pyupgrade, flake8-bugbear, flake8-comprehensions, flake8-simplify, Perflint, and Ruff-specific rules
- **Line length**: Set to 88 characters (standard for modern Python projects)
- **Target Python version**: Configured for Python 3.14 to enable modern syntax checks
- **Import organization**: Configured isort with first-party modules (api, cli, config, messaging, providers, utils)
- **Formatter settings**: Configured double quotes, space indentation, and automatic line endings
- **Ignored rules**: Disabled E501 (line too long) to avoid conflicts with the formatter
- **Type checker**: Set Python version to 3.14 for the ty environment

## Implementation Details
The configuration follows Python community best practices and enables automatic detection of common bugs, performance anti-patterns, and code simplification opportunities while maintaining consistency with the project's formatting standards.

https://claude.ai/code/session_01RVyLT88hTnfJZAVLUbWawS