### PR TITLE
docs: move model picker to summary within getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ ANTHROPIC_AUTH_TOKEN=freecc ANTHROPIC_BASE_URL=http://localhost:8082 claude
 That's it! Claude Code now uses your configured provider for free.
 
 <details>
-<summary><b>Model Picker</b></summary>
+<summary><b>Multi-Model Support (Model Picker)</b></summary>
 
 `claude-pick` is an interactive model selector that lets you choose any model from your active provider each time you launch Claude — no need to edit `MODEL` in `.env` every time you want to switch.
 


### PR DESCRIPTION
## Summary: small nit in docs

- Moves the Model Picker section from a standalone `## Model Picker` heading at the bottom into a collapsible `<details>` dropdown within the Quick Start section, placed above VSCode Extension Setup
- Adds a demo video of the model picker in action
- Fixes wording: removes "no alias or" since an alias is required for the fixed-model shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)