### PR TITLE
Readme env example consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,13 +194,13 @@ To switch back to Anthropic models, comment out the added block and reload exten
 | **OpenRouter** | Free / Paid | Varies | 200+ (GPT-4o, Claude, Step, etc.) | Model variety, fallback options |
 | **LM Studio** | Free (local) | Unlimited | Any GGUF model | Privacy, offline use, no rate limits |
 
-Switch providers by changing `PROVIDER_TYPE` in `.env`:
+Switch providers by changing `MODEL` in `.env` — use the prefix format `provider/model/name`. Invalid prefix causes an error.
 
-| Provider | `PROVIDER_TYPE` | API Key Variable | Base URL |
-|----------|-----------------|------------------|----------|
-| NVIDIA NIM | `nvidia_nim` | `NVIDIA_NIM_API_KEY` | `integrate.api.nvidia.com/v1` |
-| OpenRouter | `open_router` | `OPENROUTER_API_KEY` | `openrouter.ai/api/v1` |
-| LM Studio | `lmstudio` | (none) | `localhost:1234/v1` |
+| Provider | MODEL prefix | API Key Variable | Base URL |
+|----------|--------------|------------------|----------|
+| NVIDIA NIM | `nvidia_nim/...` | `NVIDIA_NIM_API_KEY` | `integrate.api.nvidia.com/v1` |
+| OpenRouter | `open_router/...` | `OPENROUTER_API_KEY` | `openrouter.ai/api/v1` |
+| LM Studio | `lmstudio/...` | (none) | `localhost:1234/v1` |
 
 OpenRouter gives access to hundreds of models (StepFun, OpenAI, Anthropic, etc.) through a single API. Set `MODEL` to any OpenRouter model ID.
 
@@ -340,8 +340,7 @@ Browse: [model.lmstudio.ai](https://model.lmstudio.ai)
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PROVIDER_TYPE` | Provider: `nvidia_nim`, `open_router`, or `lmstudio` | `nvidia_nim` |
-| `MODEL` | Model to use for all requests | `nvidia_nim/stepfun-ai/step-3.5-flash` |
+| `MODEL` | Model to use (prefix format: `provider/model/name`; invalid prefix causes error) | `nvidia_nim/stepfun-ai/step-3.5-flash` |
 | `NVIDIA_NIM_API_KEY` | NVIDIA API key (NIM provider) | required |
 | `OPENROUTER_API_KEY` | OpenRouter API key (OpenRouter provider) | required |
 | `LM_STUDIO_BASE_URL` | LM Studio server URL | `http://localhost:1234/v1` |


### PR DESCRIPTION
Update README to reflect the removal of `PROVIDER_TYPE` and the new `MODEL` prefix format for specifying providers.

The `PROVIDER_TYPE` environment variable was recently removed. Providers are now specified by prefixing the model name in the `MODEL` environment variable (e.g., `nvidia_nim/mistral_7b`). This PR updates the README to reflect this change, including the providers section, providers table, and configuration table.

---
<p><a href="https://cursor.com/agents?id=bc-24f1a2ad-ed89-4856-b5dc-1e56392554bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24f1a2ad-ed89-4856-b5dc-1e56392554bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

