### PR TITLE
feat: add install.sh and Docker test suite

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# install.sh — set up free-claude-code and register claude-free / claude-free-server commands
+set -euo pipefail
+
+# ── colours ────────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+info()    { echo -e "${CYAN}${BOLD}[•]${NC} $*"; }
+success() { echo -e "${GREEN}${BOLD}[✓]${NC} $*"; }
+warn()    { echo -e "${YELLOW}${BOLD}[!]${NC} $*"; }
+die()     { echo -e "${RED}${BOLD}[✗]${NC} $*" >&2; exit 1; }
+
+INSTALL_DIR="${FREE_CLAUDE_INSTALL_DIR:-$HOME/Applications/free-claude-code}"
+BIN_DIR="$HOME/.local/bin"
+PORT="${FREE_CLAUDE_PORT:-8082}"
+REPO_URL="https://github.com/Alishahryar1/free-claude-code.git"
+
+echo -e "\n${BOLD}free-claude-code installer${NC}\n"
+
+# ── 1. prerequisites ────────────────────────────────────────────────────────────
+info "Checking prerequisites..."
+
+if ! command -v git &>/dev/null; then
+    die "git not found. Install git and re-run."
+fi
+
+if ! command -v claude &>/dev/null; then
+    die "claude (Claude Code CLI) not found.\nInstall it from https://github.com/anthropics/claude-code and re-run."
+fi
+
+if ! command -v uv &>/dev/null; then
+    warn "uv not found. Installing uv..."
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    # make uv available in this session
+    export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+    if ! command -v uv &>/dev/null; then
+        die "uv install failed. Install manually from https://github.com/astral-sh/uv and re-run."
+    fi
+    success "uv installed."
+fi
+
+UV_BIN="$(command -v uv)"
+success "Prerequisites OK  (uv: $UV_BIN)"
+
+# ── 2. clone or update ──────────────────────────────────────────────────────────
+if [ -d "$INSTALL_DIR/.git" ]; then
+    info "Updating existing repo at $INSTALL_DIR ..."
+    git -C "$INSTALL_DIR" pull --ff-only
+else
+    # If the script is being run from inside the repo (not via curl|bash), install in-place
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "$SCRIPT_DIR/server.py" ] && [ -f "$SCRIPT_DIR/pyproject.toml" ]; then
+        info "Running from repo — installing in-place at $INSTALL_DIR ..."
+        if [ "$SCRIPT_DIR" != "$INSTALL_DIR" ]; then
+            mkdir -p "$(dirname "$INSTALL_DIR")"
+            cp -r "$SCRIPT_DIR" "$INSTALL_DIR"
+        fi
+    else
+        info "Cloning repo to $INSTALL_DIR ..."
+        mkdir -p "$(dirname "$INSTALL_DIR")"
+        git clone "$REPO_URL" "$INSTALL_DIR"
+    fi
+fi
+success "Repo at $INSTALL_DIR"
+
+# ── 3. python venv ──────────────────────────────────────────────────────────────
+info "Setting up Python virtual environment..."
+( cd "$INSTALL_DIR" && "$UV_BIN" sync )
+success "Virtual environment ready"
+
+# ── 4. .env ─────────────────────────────────────────────────────────────────────
+if [ ! -f "$INSTALL_DIR/.env" ]; then
+    cp "$INSTALL_DIR/.env.example" "$INSTALL_DIR/.env"
+    warn ".env created from .env.example — edit $INSTALL_DIR/.env to set your API key."
+else
+    info ".env already exists, skipping."
+fi
+
+# ── 5. ~/.local/bin scripts ─────────────────────────────────────────────────────
+mkdir -p "$BIN_DIR"
+
+info "Writing $BIN_DIR/claude-free-server ..."
+cat > "$BIN_DIR/claude-free-server" <<SCRIPT
+#!/usr/bin/env bash
+cd "${INSTALL_DIR}" && .venv/bin/uvicorn server:app --host 0.0.0.0 --port ${PORT}
+SCRIPT
+chmod +x "$BIN_DIR/claude-free-server"
+
+info "Writing $BIN_DIR/claude-free ..."
+cat > "$BIN_DIR/claude-free" <<SCRIPT
+#!/usr/bin/env bash
+_SERVER_STARTED=0
+
+if ! curl -s --max-time 1 http://localhost:${PORT}/health >/dev/null 2>&1; then
+    echo "Starting free-claude-code server in background..."
+    ( cd "${INSTALL_DIR}" && \\
+        exec .venv/bin/uvicorn server:app --host 0.0.0.0 --port ${PORT} \\
+        >> "${INSTALL_DIR}/server.log" 2>&1 ) &
+    _SERVER_PID=\$!
+    _SERVER_STARTED=1
+
+    for i in \$(seq 1 15); do
+        sleep 1
+        if curl -s --max-time 1 http://localhost:${PORT}/health >/dev/null 2>&1; then
+            echo "Server ready."
+            break
+        fi
+        if [ "\$i" -eq 15 ]; then
+            echo "Warning: server may not be ready yet, proceeding anyway..."
+        fi
+    done
+fi
+
+_cleanup() {
+    if [ "\$_SERVER_STARTED" -eq 1 ] && kill -0 "\$_SERVER_PID" 2>/dev/null; then
+        echo "Stopping free-claude-code server..."
+        kill "\$_SERVER_PID" 2>/dev/null
+    fi
+}
+trap _cleanup EXIT INT TERM
+
+ANTHROPIC_AUTH_TOKEN=freecc ANTHROPIC_BASE_URL=http://localhost:${PORT} claude "\$@"
+SCRIPT
+chmod +x "$BIN_DIR/claude-free"
+
+success "Scripts installed to $BIN_DIR"
+
+# ── 6. PATH ─────────────────────────────────────────────────────────────────────
+add_to_path() {
+    local rc_file="$1"
+    local line='export PATH="$HOME/.local/bin:$PATH"'
+    if [ -f "$rc_file" ] && grep -q '\.local/bin' "$rc_file" 2>/dev/null; then
+        return 0
+    fi
+    if [ -f "$rc_file" ] || [ "${2:-}" = "create" ]; then
+        echo -e "\n# free-claude-code\n$line" >> "$rc_file"
+        echo "$rc_file"
+    fi
+}
+
+PATCHED=""
+[ -n "$(add_to_path "$HOME/.zshrc")"       ] && PATCHED="$HOME/.zshrc"
+[ -n "$(add_to_path "$HOME/.bashrc")"      ] && PATCHED="${PATCHED:+$PATCHED, }$HOME/.bashrc"
+[ -n "$(add_to_path "$HOME/.bash_profile")"  ] && PATCHED="${PATCHED:+$PATCHED, }$HOME/.bash_profile"
+
+if [ -n "$PATCHED" ]; then
+    success "Added ~/.local/bin to PATH in: $PATCHED"
+else
+    info "~/.local/bin already in PATH."
+fi
+
+# make commands available in the current session
+export PATH="$BIN_DIR:$PATH"
+
+# ── 7. summary ──────────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}──────────────────────────────────────────${NC}"
+echo -e "${GREEN}${BOLD} Installation complete!${NC}"
+echo -e "${BOLD}──────────────────────────────────────────${NC}"
+echo
+echo -e "  ${BOLD}Next step:${NC} edit your API key in"
+echo -e "    ${CYAN}$INSTALL_DIR/.env${NC}"
+echo
+echo -e "  ${BOLD}Commands:${NC}"
+echo -e "    ${CYAN}claude-free${NC}         — start Claude Code (auto-starts server)"
+echo -e "    ${CYAN}claude-free-server${NC}  — run the proxy server in the foreground"
+echo
+if [ -n "$PATCHED" ]; then
+    echo -e "  ${YELLOW}Reload your shell or run:${NC}  source ~/.zshrc"
+    echo
+fi

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH="/root/.local/bin:/root/.cargo/bin:$PATH"
+
+# ── system deps ────────────────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y \
+    git curl ca-certificates nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── install uv ─────────────────────────────────────────────────────────────────
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# ── install claude code cli (or stub if npm fails) ────────────────────────────
+RUN npm install -g @anthropic-ai/claude-code --ignore-scripts 2>/dev/null || \
+    ( mkdir -p /usr/local/bin && \
+      printf '#!/usr/bin/env node\nprocess.exit(0);\n' > /usr/local/bin/claude && \
+      chmod +x /usr/local/bin/claude )
+
+# ── copy repo ──────────────────────────────────────────────────────────────────
+COPY . /repo
+WORKDIR /repo
+
+# ── run install script ─────────────────────────────────────────────────────────
+ENV HOME=/root
+RUN FREE_CLAUDE_INSTALL_DIR=/opt/free-claude-code bash install.sh
+
+# ── test entrypoint ────────────────────────────────────────────────────────────
+COPY test/docker-entrypoint.sh /test.sh
+RUN chmod +x /test.sh
+CMD ["/test.sh"]

--- a/test/docker-entrypoint.sh
+++ b/test/docker-entrypoint.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# docker-entrypoint.sh — post-install verification suite
+set -euo pipefail
+
+PASS=0; FAIL=0
+GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[1;33m'; BOLD='\033[1m'; NC='\033[0m'
+
+ok()   { echo -e "  ${GREEN}${BOLD}PASS${NC}  $*"; (( PASS++ )) || true; }
+fail() { echo -e "  ${RED}${BOLD}FAIL${NC}  $*"; (( FAIL++ )) || true; }
+section() { echo -e "\n${BOLD}$*${NC}"; }
+
+INSTALL_DIR="/opt/free-claude-code"
+BIN_DIR="$HOME/.local/bin"
+PORT=8082
+
+echo -e "${BOLD}╔══════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║   free-claude-code install verification  ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════╝${NC}"
+
+# ── 1. files ────────────────────────────────────────────────────────────────────
+section "1. Installed files"
+
+[ -f "$INSTALL_DIR/server.py" ]         && ok "server.py present"           || fail "server.py missing"
+[ -f "$INSTALL_DIR/pyproject.toml" ]    && ok "pyproject.toml present"      || fail "pyproject.toml missing"
+[ -f "$INSTALL_DIR/.env" ]              && ok ".env created"                 || fail ".env missing"
+[ -f "$INSTALL_DIR/.env.example" ]      && ok ".env.example present"        || fail ".env.example missing"
+
+# ── 2. scripts ──────────────────────────────────────────────────────────────────
+section "2. CLI scripts"
+
+[ -f "$BIN_DIR/claude-free" ]           && ok "claude-free exists"          || fail "claude-free missing"
+[ -f "$BIN_DIR/claude-free-server" ]    && ok "claude-free-server exists"   || fail "claude-free-server missing"
+[ -x "$BIN_DIR/claude-free" ]           && ok "claude-free is executable"   || fail "claude-free not executable"
+[ -x "$BIN_DIR/claude-free-server" ]    && ok "claude-free-server is executable" || fail "claude-free-server not executable"
+
+# scripts reference correct install dir
+grep -q "$INSTALL_DIR" "$BIN_DIR/claude-free"        && ok "claude-free references correct INSTALL_DIR"        || fail "claude-free has wrong path"
+grep -q "$INSTALL_DIR" "$BIN_DIR/claude-free-server" && ok "claude-free-server references correct INSTALL_DIR" || fail "claude-free-server has wrong path"
+
+# scripts reference correct port
+grep -q "$PORT" "$BIN_DIR/claude-free"        && ok "claude-free references port $PORT"        || fail "claude-free wrong port"
+grep -q "$PORT" "$BIN_DIR/claude-free-server" && ok "claude-free-server references port $PORT" || fail "claude-free-server wrong port"
+
+# auto-start logic present
+grep -q "_SERVER_STARTED" "$BIN_DIR/claude-free"  && ok "auto-start logic present"  || fail "auto-start logic missing"
+grep -q "_cleanup"         "$BIN_DIR/claude-free"  && ok "auto-stop trap present"    || fail "auto-stop trap missing"
+
+# ── 3. venv ─────────────────────────────────────────────────────────────────────
+section "3. Python virtual environment"
+
+[ -d "$INSTALL_DIR/.venv" ]                       && ok ".venv directory exists"         || fail ".venv missing"
+[ -f "$INSTALL_DIR/.venv/bin/python" ]            && ok ".venv/bin/python exists"        || fail ".venv/bin/python missing"
+[ -f "$INSTALL_DIR/.venv/bin/uvicorn" ]           && ok ".venv/bin/uvicorn exists"       || fail ".venv/bin/uvicorn missing"
+
+# shebang must point to new install dir (not stale)
+SHEBANG=$(head -1 "$INSTALL_DIR/.venv/bin/uvicorn")
+[[ "$SHEBANG" == *"$INSTALL_DIR"* ]] \
+    && ok "uvicorn shebang points to correct path ($SHEBANG)" \
+    || fail "uvicorn shebang is stale: $SHEBANG"
+
+# key python packages importable
+"$INSTALL_DIR/.venv/bin/python" -c "import loguru"   && ok "loguru importable"   || fail "loguru missing"
+"$INSTALL_DIR/.venv/bin/python" -c "import fastapi"  && ok "fastapi importable"  || fail "fastapi missing"
+"$INSTALL_DIR/.venv/bin/python" -c "import uvicorn"  && ok "uvicorn importable"  || fail "uvicorn missing"
+"$INSTALL_DIR/.venv/bin/python" -c "import httpx"    && ok "httpx importable"    || fail "httpx missing"
+
+# ── 4. server startup ───────────────────────────────────────────────────────────
+section "4. Server startup & health"
+
+# Use lmstudio provider so no API key is required for server to boot
+cat > "$INSTALL_DIR/.env" <<EOF
+PROVIDER_TYPE=lmstudio
+MODEL=lmstudio/test-model
+LM_STUDIO_BASE_URL=http://localhost:1234/v1
+MESSAGING_PLATFORM=discord
+DISCORD_BOT_TOKEN=
+ALLOWED_DISCORD_CHANNELS=
+CLAUDE_WORKSPACE=./agent_workspace
+MAX_CLI_SESSIONS=10
+EOF
+
+# Start server in background
+cd "$INSTALL_DIR"
+.venv/bin/uvicorn server:app --host 0.0.0.0 --port $PORT >> server.log 2>&1 &
+SERVER_PID=$!
+
+# Wait up to 15s for /health
+HEALTHY=0
+for i in $(seq 1 15); do
+    sleep 1
+    if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+        HEALTHY=1; break
+    fi
+done
+
+if [ $HEALTHY -eq 1 ]; then
+    ok "Server started (PID $SERVER_PID)"
+
+    # /health returns correct JSON
+    RESP=$(curl -sf "http://localhost:$PORT/health")
+    [[ "$RESP" == *"healthy"* ]] \
+        && ok "/health returns {status: healthy}" \
+        || fail "/health unexpected response: $RESP"
+
+    # / root endpoint accessible
+    curl -sf "http://localhost:$PORT/" >/dev/null 2>&1 \
+        && ok "/ root endpoint responds" \
+        || fail "/ root endpoint unreachable"
+else
+    fail "Server did not start within 15s"
+    echo "--- server.log ---"
+    cat "$INSTALL_DIR/server.log" | tail -30
+fi
+
+kill $SERVER_PID 2>/dev/null || true
+sleep 1
+kill -9 $SERVER_PID 2>/dev/null || true
+# Wait for port to be fully released before auto-start test
+for i in $(seq 1 15); do
+    sleep 1
+    if ! curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then break; fi
+done
+
+# ── 5. auto-start check (claude-free without server) ───────────────────────────
+section "5. claude-free auto-start logic"
+
+# Verify server is down
+sleep 1
+if curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+    warn "Server still up, skipping auto-start test"
+else
+    # Run claude-free in background; it should start the server then call claude
+    # We stub 'claude' to exit immediately so the test doesn't hang
+    mkdir -p /tmp/stub-bin
+    printf '#!/bin/sh\nexit 0\n' > /tmp/stub-bin/claude && chmod +x /tmp/stub-bin/claude
+
+    OUTPUT=$(PATH="/tmp/stub-bin:$BIN_DIR:$PATH" timeout 35 bash "$BIN_DIR/claude-free" --version 2>&1 || true)
+    echo "$OUTPUT" | grep -q "Starting free-claude-code server" \
+        && ok "claude-free auto-starts server when not running" \
+        || { fail "claude-free did not print startup message"; echo "    output was: $(echo "$OUTPUT" | head -3)"; }
+
+    # Server should have been killed after claude-free exited
+    sleep 2
+    if ! curl -sf "http://localhost:$PORT/health" >/dev/null 2>&1; then
+        ok "Server auto-stopped after claude-free exited"
+    else
+        fail "Server still running after claude-free exited"
+        # kill server using ss (lsof not available in minimal containers)
+        ss -tlnp "sport = :$PORT" 2>/dev/null | awk 'NR>1 {print $6}' | \
+            grep -oP 'pid=\K[0-9]+' | xargs -r kill 2>/dev/null || true
+    fi
+fi
+
+# ── summary ─────────────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}══════════════════════════════════════════${NC}"
+if [ $FAIL -eq 0 ]; then
+    echo -e "  ${GREEN}${BOLD}ALL $PASS TESTS PASSED${NC}"
+else
+    echo -e "  ${GREEN}${BOLD}$PASS passed${NC}  ${RED}${BOLD}$FAIL failed${NC}"
+fi
+echo -e "${BOLD}══════════════════════════════════════════${NC}\n"
+
+exit $FAIL


### PR DESCRIPTION
## What this adds

### `install.sh` — one-command setup
```bash
curl -fsSL https://raw.githubusercontent.com/Alishahryar1/free-claude-code/main/install.sh | bash
# or after cloning:
bash install.sh
```

- Checks prerequisites (`git`, `claude`, `uv`) — auto-installs `uv` if missing
- Clones repo (or copies in-place when run from inside the repo)
- Runs `uv sync` to build `.venv` with correct absolute paths
- Copies `.env.example` → `.env` on first run
- Writes two commands to `~/.local/bin`:
  - **`claude-free`** — auto-starts the proxy server if not running, launches `claude`, stops server on exit/Ctrl+C
  - **`claude-free-server`** — run the proxy in the foreground
- Patches `PATH` in `.zshrc` / `.bashrc` / `.bash_profile`
- Install dir and port overridable via env vars: `FREE_CLAUDE_INSTALL_DIR` and `FREE_CLAUDE_PORT`

### `test/` — Docker verification suite
- `test/Dockerfile`: Ubuntu 24.04 image that runs `install.sh` from scratch
- `test/docker-entrypoint.sh`: 27-test suite covering:
  - Installed files present
  - Scripts exist, are executable, reference correct paths/port
  - Auto-start and auto-stop logic present
  - `.venv` integrity (shebang paths, key packages importable)
  - Server startup and `/health` response
  - `claude-free` auto-starts server when not running
  - Server auto-stops when `claude-free` exits

All 27 tests pass on Linux (Ubuntu 24.04 via Docker).