### PR TITLE
feat: relaygpu provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ OPENROUTER_API_KEY=""
 DEEPSEEK_API_KEY=""
 
 
+# RelayGPU Config
+RELAYGPU_API_KEY=""
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
@@ -20,7 +24,7 @@ LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp"
+# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "relaygpu"
 MODEL_OPUS="nvidia_nim/z-ai/glm4.7"
 MODEL_SONNET="open_router/arcee-ai/trinity-large-preview:free"
 MODEL_HAIKU="open_router/stepfun/step-3.5-flash:free"
@@ -39,6 +43,7 @@ NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""
 LMSTUDIO_PROXY=""
 LLAMACPP_PROXY=""
+RELAYGPU_PROXY=""
 
 PROVIDER_RATE_LIMIT=40
 PROVIDER_RATE_WINDOW=60

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Code style: Ruff](https://img.shields.io/badge/code%20formatting-ruff-f5a623.svg?style=for-the-badge)](https://github.com/astral-sh/ruff)
 [![Logging: Loguru](https://img.shields.io/badge/logging-loguru-4ecdc4.svg?style=for-the-badge)](https://github.com/Delgan/loguru)
 
-A lightweight proxy that routes Claude Code's Anthropic API calls to **NVIDIA NIM** (40 req/min free), **OpenRouter** (hundreds of models), **DeepSeek** (direct API), **LM Studio** (fully local), or **llama.cpp** (local with Anthropic endpoints).
+A lightweight proxy that routes Claude Code's Anthropic API calls to **NVIDIA NIM** (40 req/min free), **OpenRouter** (hundreds of models), **DeepSeek** (direct API), **RelayGPU** (OpenGPU Network gateway), **LM Studio** (fully local), or **llama.cpp** (local with Anthropic endpoints).
 
 [Quick Start](#quick-start) · [Providers](#providers) · [Discord Bot](#discord-bot) · [Configuration](#configuration) · [Development](#development) · [Contributing](#contributing)
 
@@ -31,7 +31,7 @@ A lightweight proxy that routes Claude Code's Anthropic API calls to **NVIDIA NI
 | -------------------------- | ----------------------------------------------------------------------------------------------- |
 | **Zero Cost**              | 40 req/min free on NVIDIA NIM. Free models on OpenRouter. Fully local with LM Studio            |
 | **Drop-in Replacement**    | Set 2 env vars. No modifications to Claude Code CLI or VSCode extension needed                  |
-| **5 Providers**            | NVIDIA NIM, OpenRouter, DeepSeek, LM Studio (local), llama.cpp (`llama-server`)                  |
+| **6 Providers**            | NVIDIA NIM, OpenRouter, DeepSeek, RelayGPU, LM Studio (local), llama.cpp (`llama-server`)        |
 | **Per-Model Mapping**      | Route Opus / Sonnet / Haiku to different models and providers. Mix providers freely             |
 | **Thinking Token Support** | Parses `<think>` tags and `reasoning_content` into native Claude thinking blocks                |
 | **Heuristic Tool Parser**  | Models outputting tool calls as text are auto-parsed into structured tool use                   |
@@ -49,6 +49,7 @@ A lightweight proxy that routes Claude Code's Anthropic API calls to **NVIDIA NI
    - **NVIDIA NIM**: [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys)
    - **OpenRouter**: [openrouter.ai/keys](https://openrouter.ai/keys)
    - **DeepSeek**: [platform.deepseek.com/api_keys](https://platform.deepseek.com/api_keys)
+   - **RelayGPU**: [relaygpu.com](https://relaygpu.com)
    - **LM Studio**: No API key needed. Run locally with [LM Studio](https://lmstudio.ai)
    - **llama.cpp**: No API key needed. Run `llama-server` locally.
 2. Install [Claude Code](https://github.com/anthropics/claude-code)
@@ -111,6 +112,20 @@ MODEL_OPUS="deepseek/deepseek-reasoner"
 MODEL_SONNET="deepseek/deepseek-chat"
 MODEL_HAIKU="deepseek/deepseek-chat"
 MODEL="deepseek/deepseek-chat"                      # fallback
+```
+
+</details>
+
+<details>
+<summary><b>RelayGPU</b> (OpenGPU Network gateway, OpenAI-compatible)</summary>
+
+```dotenv
+RELAYGPU_API_KEY="relay_sk_your-key-here"
+
+MODEL_OPUS="relaygpu/deepseek-ai/DeepSeek-V3.1"
+MODEL_SONNET="relaygpu/Qwen/Qwen3.5-397B-A17B-FP8"
+MODEL_HAIKU="relaygpu/moonshotai/kimi-k2.5"
+MODEL="relaygpu/moonshotai/kimi-k2.5"               # fallback
 ```
 
 </details>
@@ -309,6 +324,7 @@ The proxy also exposes Claude-compatible probe routes: `GET /v1/models`, `POST /
 | **NVIDIA NIM** | Free         | 40 req/min | Daily driver, generous free tier     |
 | **OpenRouter** | Free / Paid  | Varies     | Model variety, fallback options      |
 | **DeepSeek**   | Usage-based  | Varies     | Direct access to DeepSeek chat/reasoner |
+| **RelayGPU**   | Usage-based  | Varies     | Multi-provider gateway (GPT, DeepSeek, Qwen, Kimi) |
 | **LM Studio**  | Free (local) | Unlimited  | Privacy, offline use, no rate limits |
 | **llama.cpp**  | Free (local) | Unlimited  | Lightweight local inference engine   |
 
@@ -319,6 +335,7 @@ Models use a prefix format: `provider_prefix/model/name`. An invalid prefix caus
 | NVIDIA NIM | `nvidia_nim/...`  | `NVIDIA_NIM_API_KEY` | `integrate.api.nvidia.com/v1` |
 | OpenRouter | `open_router/...` | `OPENROUTER_API_KEY` | `openrouter.ai/api/v1`        |
 | DeepSeek   | `deepseek/...`    | `DEEPSEEK_API_KEY`   | `api.deepseek.com`            |
+| RelayGPU   | `relaygpu/...`    | `RELAYGPU_API_KEY`   | `relay.opengpu.network/v2/openai/v1` |
 | LM Studio  | `lmstudio/...`    | (none)               | `localhost:1234/v1`           |
 | llama.cpp  | `llamacpp/...`    | (none)               | `localhost:8080/v1`           |
 
@@ -360,6 +377,19 @@ DeepSeek currently exposes the direct API models:
 - `deepseek/deepseek-reasoner`
 
 Browse: [api-docs.deepseek.com](https://api-docs.deepseek.com)
+
+</details>
+
+<details>
+<summary><b>RelayGPU models</b></summary>
+
+RelayGPU proxies models from multiple backends through a single OpenAI-compatible endpoint:
+
+- `relaygpu/deepseek-ai/DeepSeek-V3.1`
+- `relaygpu/Qwen/Qwen3.5-397B-A17B-FP8`
+- `relaygpu/moonshotai/kimi-k2.5`
+
+Browse: [opengpu-network.gitbook.io/relay](https://opengpu-network.gitbook.io/relay)
 
 </details>
 
@@ -485,12 +515,14 @@ Configure via `WHISPER_DEVICE` (`cpu` | `cuda` | `nvidia_nim`) and `WHISPER_MODE
 | `ENABLE_THINKING`    | Global switch for provider reasoning requests and Claude thinking blocks. Set `false` to hide thinking across all providers. | `true` |
 | `OPENROUTER_API_KEY` | OpenRouter API key                                                    | required for OpenRouter                           |
 | `DEEPSEEK_API_KEY`   | DeepSeek API key                                                      | required for DeepSeek                             |
+| `RELAYGPU_API_KEY`   | RelayGPU API key                                                      | required for RelayGPU                             |
 | `LM_STUDIO_BASE_URL` | LM Studio server URL                                                  | `http://localhost:1234/v1`                        |
 | `LLAMACPP_BASE_URL`  | llama.cpp server URL                                                  | `http://localhost:8080/v1`                        |
 | `NVIDIA_NIM_PROXY`   | Optional proxy URL for NVIDIA NIM requests (`http://...` or `socks5://...`) | `""` |
 | `OPENROUTER_PROXY`   | Optional proxy URL for OpenRouter requests (`http://...` or `socks5://...`) | `""` |
 | `LMSTUDIO_PROXY`     | Optional proxy URL for LM Studio requests (`http://...` or `socks5://...`) | `""` |
 | `LLAMACPP_PROXY`     | Optional proxy URL for llama.cpp requests (`http://...` or `socks5://...`) | `""` |
+| `RELAYGPU_PROXY`     | Optional proxy URL for RelayGPU requests (`http://...` or `socks5://...`) | `""` |
 
 ### Rate Limiting & Timeouts
 
@@ -548,7 +580,7 @@ See [`.env.example`](.env.example) for all supported parameters.
 free-claude-code/
 ├── server.py              # Entry point
 ├── api/                   # FastAPI routes, request detection, optimization handlers
-├── providers/             # BaseProvider, OpenAICompatibleProvider, NIM, OpenRouter, DeepSeek, LM Studio, llamacpp
+├── providers/             # BaseProvider, OpenAICompatibleProvider, NIM, OpenRouter, DeepSeek, RelayGPU, LM Studio, llamacpp
 │   └── common/            # Shared utils (SSE builder, message converter, parsers, error mapping)
 ├── messaging/             # MessagingPlatform ABC + Discord/Telegram bots, session management
 ├── config/                # Settings, NIM config, logging

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -13,6 +13,7 @@ from providers.llamacpp import LlamaCppProvider
 from providers.lmstudio import LMStudioProvider
 from providers.nvidia_nim import NVIDIA_NIM_BASE_URL, NvidiaNimProvider
 from providers.open_router import OPENROUTER_BASE_URL, OpenRouterProvider
+from providers.relaygpu import RELAYGPU_BASE_URL, RelayGpuProvider
 
 # Provider registry: keyed by provider type string, lazily populated
 _providers: dict[str, BaseProvider] = {}
@@ -36,6 +37,7 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
         "open_router": _get_proxy_value(settings, "open_router_proxy"),
         "lmstudio": _get_proxy_value(settings, "lmstudio_proxy"),
         "llamacpp": _get_proxy_value(settings, "llamacpp_proxy"),
+        "relaygpu": _get_proxy_value(settings, "relaygpu_proxy"),
     }
     proxy = _proxy_map.get(provider_type, "")
 
@@ -123,13 +125,32 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
             proxy=proxy,
         )
         return LlamaCppProvider(config)
+    if provider_type == "relaygpu":
+        if not settings.relaygpu_api_key or not settings.relaygpu_api_key.strip():
+            raise AuthenticationError(
+                "RELAYGPU_API_KEY is not set. Add it to your .env file. "
+                "Get a key at https://relaygpu.com"
+            )
+        config = ProviderConfig(
+            api_key=settings.relaygpu_api_key,
+            base_url=RELAYGPU_BASE_URL,
+            rate_limit=settings.provider_rate_limit,
+            rate_window=settings.provider_rate_window,
+            max_concurrency=settings.provider_max_concurrency,
+            http_read_timeout=settings.http_read_timeout,
+            http_write_timeout=settings.http_write_timeout,
+            http_connect_timeout=settings.http_connect_timeout,
+            enable_thinking=settings.enable_thinking,
+            proxy=proxy,
+        )
+        return RelayGpuProvider(config)
     logger.error(
-        "Unknown provider_type: '{}'. Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'",
+        "Unknown provider_type: '{}'. Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp', 'relaygpu'",
         provider_type,
     )
     raise ValueError(
         f"Unknown provider_type: '{provider_type}'. "
-        f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'"
+        f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp', 'relaygpu'"
     )
 
 

--- a/config/env.example
+++ b/config/env.example
@@ -10,13 +10,17 @@ OPENROUTER_API_KEY=""
 DEEPSEEK_API_KEY=""
 
 
+# RelayGPU Config
+RELAYGPU_API_KEY=""
+
+
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp"
+# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "relaygpu"
 MODEL_OPUS="nvidia_nim/z-ai/glm4.7"
 MODEL_SONNET="open_router/arcee-ai/trinity-large-preview:free"
 MODEL_HAIKU="open_router/stepfun/step-3.5-flash:free"

--- a/config/settings.py
+++ b/config/settings.py
@@ -84,6 +84,9 @@ class Settings(BaseSettings):
     # ==================== DeepSeek Config ====================
     deepseek_api_key: str = Field(default="", validation_alias="DEEPSEEK_API_KEY")
 
+    # ==================== RelayGPU Config ====================
+    relaygpu_api_key: str = Field(default="", validation_alias="RELAYGPU_API_KEY")
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord"
     messaging_platform: str = Field(
@@ -121,6 +124,7 @@ class Settings(BaseSettings):
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
     lmstudio_proxy: str = Field(default="", validation_alias="LMSTUDIO_PROXY")
     llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
+    relaygpu_proxy: str = Field(default="", validation_alias="RELAYGPU_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")
@@ -234,6 +238,7 @@ class Settings(BaseSettings):
             "deepseek",
             "lmstudio",
             "llamacpp",
+            "relaygpu",
         )
         if "/" not in v:
             raise ValueError(
@@ -245,7 +250,7 @@ class Settings(BaseSettings):
         if provider not in valid_providers:
             raise ValueError(
                 f"Invalid provider: '{provider}'. "
-                f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'"
+                f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp', 'relaygpu'"
             )
         return v
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -14,6 +14,7 @@ from .llamacpp import LlamaCppProvider
 from .lmstudio import LMStudioProvider
 from .nvidia_nim import NvidiaNimProvider
 from .open_router import OpenRouterProvider
+from .relaygpu import RelayGpuProvider
 
 __all__ = [
     "APIError",
@@ -29,4 +30,5 @@ __all__ = [
     "ProviderConfig",
     "ProviderError",
     "RateLimitError",
+    "RelayGpuProvider",
 ]

--- a/providers/relaygpu/__init__.py
+++ b/providers/relaygpu/__init__.py
@@ -1,0 +1,5 @@
+"""RelayGPU provider exports."""
+
+from .client import RELAYGPU_BASE_URL, RelayGpuProvider
+
+__all__ = ["RELAYGPU_BASE_URL", "RelayGpuProvider"]

--- a/providers/relaygpu/client.py
+++ b/providers/relaygpu/client.py
@@ -1,0 +1,29 @@
+"""RelayGPU provider implementation."""
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.openai_compat import OpenAICompatibleProvider
+
+from .request import build_request_body
+
+RELAYGPU_BASE_URL = "https://relay.opengpu.network/v2/openai/v1"
+
+
+class RelayGpuProvider(OpenAICompatibleProvider):
+    """RelayGPU provider using OpenAI-compatible chat completions."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="RELAYGPU",
+            base_url=config.base_url or RELAYGPU_BASE_URL,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(self, request: Any) -> dict:
+        """Internal helper for tests and shared building."""
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request),
+        )

--- a/providers/relaygpu/request.py
+++ b/providers/relaygpu/request.py
@@ -1,0 +1,43 @@
+"""Request builder for RelayGPU provider."""
+
+from typing import Any
+
+from loguru import logger
+
+from providers.common.message_converter import build_base_request_body
+
+
+def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+    """Build OpenAI-format request body from an Anthropic request for RelayGPU."""
+    logger.debug(
+        "RELAYGPU_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+    body = build_base_request_body(
+        request_data,
+        include_reasoning_content=True,
+    )
+
+    extra_body: dict[str, Any] = {}
+    request_extra = getattr(request_data, "extra_body", None)
+    if request_extra:
+        extra_body.update(request_extra)
+
+    if thinking_enabled:
+        # Qwen-family models routed through RelayGPU accept an explicit toggle
+        # via chat_template_kwargs; providers that ignore it see no effect.
+        chat_template_kwargs = extra_body.setdefault("chat_template_kwargs", {})
+        if isinstance(chat_template_kwargs, dict):
+            chat_template_kwargs.setdefault("enable_thinking", True)
+
+    if extra_body:
+        body["extra_body"] = extra_body
+
+    logger.debug(
+        "RELAYGPU_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body

--- a/tests/api/test_dependencies.py
+++ b/tests/api/test_dependencies.py
@@ -14,6 +14,7 @@ from providers.deepseek import DeepSeekProvider
 from providers.lmstudio import LMStudioProvider
 from providers.nvidia_nim import NvidiaNimProvider
 from providers.open_router import OpenRouterProvider
+from providers.relaygpu import RELAYGPU_BASE_URL, RelayGpuProvider
 
 
 def _make_mock_settings(**overrides):
@@ -27,6 +28,7 @@ def _make_mock_settings(**overrides):
     mock.provider_max_concurrency = 5
     mock.open_router_api_key = "test_openrouter_key"
     mock.deepseek_api_key = "test_deepseek_key"
+    mock.relaygpu_api_key = "test_relaygpu_key"
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.nim = NimSettings()
     mock.http_read_timeout = 300.0
@@ -283,6 +285,65 @@ async def test_get_provider_open_router_missing_api_key():
         assert exc_info.value.status_code == 503
         assert "OPENROUTER_API_KEY" in exc_info.value.detail
         assert "openrouter.ai" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_provider_relaygpu():
+    """Test that provider_type=relaygpu returns RelayGpuProvider."""
+    with patch("api.dependencies.get_settings") as mock_settings:
+        mock_settings.return_value = _make_mock_settings(provider_type="relaygpu")
+
+        provider = get_provider()
+
+        assert isinstance(provider, RelayGpuProvider)
+        assert provider._base_url == RELAYGPU_BASE_URL
+        assert provider._api_key == "test_relaygpu_key"
+        assert provider._config.enable_thinking is True
+
+
+@pytest.mark.asyncio
+async def test_get_provider_relaygpu_uses_fixed_base_url():
+    """RelayGPU provider always uses the fixed provider base URL."""
+    with patch("api.dependencies.get_settings") as mock_settings:
+        mock_settings.return_value = _make_mock_settings(provider_type="relaygpu")
+
+        provider = get_provider()
+
+        assert isinstance(provider, RelayGpuProvider)
+        assert provider._base_url == RELAYGPU_BASE_URL
+
+
+@pytest.mark.asyncio
+async def test_get_provider_relaygpu_missing_api_key():
+    """RelayGPU with empty API key raises HTTPException 503."""
+    with patch("api.dependencies.get_settings") as mock_settings:
+        mock_settings.return_value = _make_mock_settings(
+            provider_type="relaygpu",
+            relaygpu_api_key="",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_provider()
+
+        assert exc_info.value.status_code == 503
+        assert "RELAYGPU_API_KEY" in exc_info.value.detail
+        assert "relaygpu.com" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_get_provider_relaygpu_whitespace_only_api_key():
+    """RelayGPU with whitespace-only API key raises HTTPException 503."""
+    with patch("api.dependencies.get_settings") as mock_settings:
+        mock_settings.return_value = _make_mock_settings(
+            provider_type="relaygpu",
+            relaygpu_api_key="   ",
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            get_provider()
+
+        assert exc_info.value.status_code == 503
+        assert "RELAYGPU_API_KEY" in exc_info.value.detail
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_relaygpu.py
+++ b/tests/providers/test_relaygpu.py
@@ -1,0 +1,194 @@
+"""Tests for RelayGPU provider."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from providers.base import ProviderConfig
+from providers.relaygpu import RELAYGPU_BASE_URL, RelayGpuProvider
+
+
+class MockMessage:
+    def __init__(self, role, content):
+        self.role = role
+        self.content = content
+
+
+class MockBlock:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class MockRequest:
+    def __init__(self, **kwargs):
+        self.model = "openai/gpt-5.4"
+        self.messages = [MockMessage("user", "Hello")]
+        self.max_tokens = 100
+        self.temperature = 0.5
+        self.top_p = 0.9
+        self.system = "System prompt"
+        self.stop_sequences = None
+        self.tools = []
+        self.extra_body = {}
+        self.thinking = MagicMock()
+        self.thinking.enabled = True
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+@pytest.fixture
+def relaygpu_config():
+    return ProviderConfig(
+        api_key="relay_sk_test",
+        base_url=RELAYGPU_BASE_URL,
+        rate_limit=10,
+        rate_window=60,
+        enable_thinking=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_rate_limiter():
+    """Mock the global rate limiter to prevent waiting."""
+    with patch("providers.openai_compat.GlobalRateLimiter") as mock:
+        instance = mock.get_instance.return_value
+        instance.wait_if_blocked = AsyncMock(return_value=False)
+
+        async def _passthrough(fn, *args, **kwargs):
+            return await fn(*args, **kwargs)
+
+        instance.execute_with_retry = AsyncMock(side_effect=_passthrough)
+        yield instance
+
+
+@pytest.fixture
+def relaygpu_provider(relaygpu_config):
+    return RelayGpuProvider(relaygpu_config)
+
+
+def test_init(relaygpu_config):
+    """Test provider initialization uses the fixed base URL and Bearer auth."""
+    with patch("providers.openai_compat.AsyncOpenAI") as mock_openai:
+        provider = RelayGpuProvider(relaygpu_config)
+        assert provider._api_key == "relay_sk_test"
+        assert provider._base_url == RELAYGPU_BASE_URL
+        mock_openai.assert_called_once()
+        call_kwargs = mock_openai.call_args[1]
+        assert call_kwargs["api_key"] == "relay_sk_test"
+        assert call_kwargs["base_url"] == RELAYGPU_BASE_URL
+
+
+def test_base_url_constant():
+    """RelayGPU base URL points at the OpenAI-compatible endpoint."""
+    assert RELAYGPU_BASE_URL == "https://relay.opengpu.network/v2/openai/v1"
+
+
+def test_build_request_body_passes_model_and_messages(relaygpu_provider):
+    """Basic request fields are copied into the OpenAI-format body."""
+    req = MockRequest(model="deepseek-ai/DeepSeek-V3.1")
+    body = relaygpu_provider._build_request_body(req)
+
+    assert body["model"] == "deepseek-ai/DeepSeek-V3.1"
+    assert body["messages"][0]["role"] == "system"
+    assert body["messages"][1]["role"] == "user"
+    assert body["max_tokens"] == 100
+    assert body["temperature"] == 0.5
+
+
+def test_build_request_body_enables_thinking_via_chat_template_kwargs(
+    relaygpu_provider,
+):
+    """Thinking-enabled requests pass enable_thinking=True through chat_template_kwargs."""
+    req = MockRequest(model="Qwen/Qwen3.5-397B-A17B-FP8")
+    body = relaygpu_provider._build_request_body(req)
+
+    assert body["extra_body"]["chat_template_kwargs"]["enable_thinking"] is True
+
+
+def test_build_request_body_global_disable_blocks_request_thinking():
+    """Global disable suppresses provider-side thinking even if the request enables it."""
+    provider = RelayGpuProvider(
+        ProviderConfig(
+            api_key="relay_sk_test",
+            base_url=RELAYGPU_BASE_URL,
+            rate_limit=10,
+            rate_window=60,
+            enable_thinking=False,
+        )
+    )
+    req = MockRequest(model="Qwen/Qwen3.5-397B-A17B-FP8")
+    body = provider._build_request_body(req)
+
+    extra_body = body.get("extra_body", {})
+    assert "chat_template_kwargs" not in extra_body
+
+
+def test_build_request_body_request_disable_blocks_global_thinking(relaygpu_provider):
+    """Request-level disable suppresses provider-side thinking when global is enabled."""
+    req = MockRequest(model="Qwen/Qwen3.5-397B-A17B-FP8")
+    req.thinking.enabled = False
+    body = relaygpu_provider._build_request_body(req)
+
+    extra_body = body.get("extra_body", {})
+    assert "chat_template_kwargs" not in extra_body
+
+
+def test_build_request_body_preserves_caller_chat_template_kwargs(relaygpu_provider):
+    """Caller-provided chat_template_kwargs keys are preserved, not overwritten."""
+    req = MockRequest(
+        model="Qwen/Qwen3.5-397B-A17B-FP8",
+        extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+    )
+    body = relaygpu_provider._build_request_body(req)
+
+    assert body["extra_body"]["chat_template_kwargs"]["enable_thinking"] is False
+
+
+def test_build_request_body_preserves_reasoning_content(relaygpu_provider):
+    """Thinking blocks are mirrored into reasoning_content for continuation."""
+    req = MockRequest(
+        system=None,
+        messages=[
+            MockMessage(
+                "assistant",
+                [
+                    MockBlock(type="thinking", thinking="First think"),
+                    MockBlock(type="text", text="Then answer"),
+                ],
+            )
+        ],
+    )
+
+    body = relaygpu_provider._build_request_body(req)
+
+    assert body["messages"][0]["reasoning_content"] == "First think"
+
+
+@pytest.mark.asyncio
+async def test_stream_response_reasoning_content(relaygpu_provider):
+    """reasoning_content deltas are emitted as thinking blocks."""
+    req = MockRequest()
+
+    mock_chunk = MagicMock()
+    mock_chunk.choices = [
+        MagicMock(
+            delta=MagicMock(content=None, reasoning_content="Thinking..."),
+            finish_reason="stop",
+        )
+    ]
+    mock_chunk.usage = MagicMock(completion_tokens=2)
+
+    async def mock_stream():
+        yield mock_chunk
+
+    with patch.object(
+        relaygpu_provider._client.chat.completions, "create", new_callable=AsyncMock
+    ) as mock_create:
+        mock_create.return_value = mock_stream()
+
+        events = [event async for event in relaygpu_provider.stream_response(req)]
+
+        assert any(
+            '"thinking_delta"' in event and "Thinking..." in event for event in events
+        )


### PR DESCRIPTION
Adds RelayGPU as a new provider, following the same pattern as the recently-merged DeepSeek provider (#118).
RelayGPU is OpenGPU Network's OpenAI-compatible gateway that routes across multiple model families (GPT, DeepSeek, Qwen, Kimi, etc.) under a single endpoint.

## Summary
- add native RelayGPU provider via the shared OpenAI-compatible provider base
- allow relaygpu/... model prefixes in config validation
- add RELAYGPU_API_KEY and RELAYGPU_PROXY settings
- add RelayGPU entries to .env.example and config/env.example
- implement RelayGpuProvider and register it in provider dependencies
- add a RelayGPU request builder
- document RelayGPU usage in README.md
- add tests for provider dependency wiring, request building, and streaming behavior

## Motivation
RelayGPU exposes an OpenAI-compatible API and routes across multiple model families under a single endpoint and API key. This lets users access GPT, DeepSeek, Qwen, Kimi and others through the proxy while keeping the same Claude Code workflow.

## Example
```dotenv
RELAYGPU_API_KEY="relay_sk_..."
MODEL_OPUS="relaygpu/deepseek-ai/DeepSeek-V3.1"
MODEL_SONNET="relaygpu/Qwen/Qwen3.5-397B-A17B-FP8"
MODEL_HAIKU="relaygpu/moonshotai/kimi-k2.5"
MODEL="relaygpu/moonshotai/kimi-k2.5"
```
Tested end-to-end with streaming + thinking blocks. Ruff / ty / pytest pass.