### PR TITLE
feat: Add Kilo AI Gateway provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ NVIDIA_NIM_API_KEY=""
 OPENROUTER_API_KEY=""
 
 
+# Kilo AI Gateway Config
+KILO_API_KEY=""
+
+
 # DeepSeek Config
 DEEPSEEK_API_KEY=""
 
@@ -20,7 +24,7 @@ LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp"
+# Valid providers: "nvidia_nim" | "open_router" | "kilo" | "deepseek" | "lmstudio" | "llamacpp"
 MODEL_OPUS="nvidia_nim/z-ai/glm4.7"
 MODEL_SONNET="open_router/arcee-ai/trinity-large-preview:free"
 MODEL_HAIKU="open_router/stepfun/step-3.5-flash:free"
@@ -37,6 +41,7 @@ ENABLE_THINKING=true
 # Per-provider proxy support: http and socks5, example: "http://username:password@host:port"
 NVIDIA_NIM_PROXY=""
 OPENROUTER_PROXY=""
+KILO_PROXY=""
 LMSTUDIO_PROXY=""
 LLAMACPP_PROXY=""
 

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -9,6 +9,7 @@ from providers.base import BaseProvider, ProviderConfig
 from providers.common import get_user_facing_error_message
 from providers.deepseek import DEEPSEEK_BASE_URL, DeepSeekProvider
 from providers.exceptions import AuthenticationError
+from providers.kilo import KILO_BASE_URL, KiloProvider
 from providers.llamacpp import LlamaCppProvider
 from providers.lmstudio import LMStudioProvider
 from providers.nvidia_nim import NVIDIA_NIM_BASE_URL, NvidiaNimProvider
@@ -34,6 +35,7 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
     _proxy_map = {
         "nvidia_nim": _get_proxy_value(settings, "nvidia_nim_proxy"),
         "open_router": _get_proxy_value(settings, "open_router_proxy"),
+        "kilo": _get_proxy_value(settings, "kilo_proxy"),
         "lmstudio": _get_proxy_value(settings, "lmstudio_proxy"),
         "llamacpp": _get_proxy_value(settings, "llamacpp_proxy"),
     }
@@ -77,6 +79,25 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
             proxy=proxy,
         )
         return OpenRouterProvider(config)
+    if provider_type == "kilo":
+        if not settings.kilo_api_key or not settings.kilo_api_key.strip():
+            raise AuthenticationError(
+                "KILO_API_KEY is not set. Add it to your .env file. "
+                "Get a key at https://app.kilo.ai"
+            )
+        config = ProviderConfig(
+            api_key=settings.kilo_api_key,
+            base_url=KILO_BASE_URL,
+            rate_limit=settings.provider_rate_limit,
+            rate_window=settings.provider_rate_window,
+            max_concurrency=settings.provider_max_concurrency,
+            http_read_timeout=settings.http_read_timeout,
+            http_write_timeout=settings.http_write_timeout,
+            http_connect_timeout=settings.http_connect_timeout,
+            enable_thinking=settings.enable_thinking,
+            proxy=proxy,
+        )
+        return KiloProvider(config)
     if provider_type == "deepseek":
         if not settings.deepseek_api_key or not settings.deepseek_api_key.strip():
             raise AuthenticationError(
@@ -124,12 +145,12 @@ def _create_provider_for_type(provider_type: str, settings: Settings) -> BasePro
         )
         return LlamaCppProvider(config)
     logger.error(
-        "Unknown provider_type: '{}'. Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'",
+        "Unknown provider_type: '{}'. Supported: 'nvidia_nim', 'open_router', 'kilo', 'deepseek', 'lmstudio', 'llamacpp'",
         provider_type,
     )
     raise ValueError(
         f"Unknown provider_type: '{provider_type}'. "
-        f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'"
+        f"Supported: 'nvidia_nim', 'open_router', 'kilo', 'deepseek', 'lmstudio', 'llamacpp'"
     )
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -81,6 +81,9 @@ class Settings(BaseSettings):
     # ==================== OpenRouter Config ====================
     open_router_api_key: str = Field(default="", validation_alias="OPENROUTER_API_KEY")
 
+    # ==================== Kilo AI Gateway Config ====================
+    kilo_api_key: str = Field(default="", validation_alias="KILO_API_KEY")
+
     # ==================== DeepSeek Config ====================
     deepseek_api_key: str = Field(default="", validation_alias="DEEPSEEK_API_KEY")
 
@@ -119,6 +122,7 @@ class Settings(BaseSettings):
     # ==================== Per-Provider Proxy ====================
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
+    kilo_proxy: str = Field(default="", validation_alias="KILO_PROXY")
     lmstudio_proxy: str = Field(default="", validation_alias="LMSTUDIO_PROXY")
     llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
 
@@ -231,6 +235,7 @@ class Settings(BaseSettings):
         valid_providers = (
             "nvidia_nim",
             "open_router",
+            "kilo",
             "deepseek",
             "lmstudio",
             "llamacpp",
@@ -245,7 +250,7 @@ class Settings(BaseSettings):
         if provider not in valid_providers:
             raise ValueError(
                 f"Invalid provider: '{provider}'. "
-                f"Supported: 'nvidia_nim', 'open_router', 'deepseek', 'lmstudio', 'llamacpp'"
+                f"Supported: 'nvidia_nim', 'open_router', 'kilo', 'deepseek', 'lmstudio', 'llamacpp'"
             )
         return v
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -10,6 +10,7 @@ from .exceptions import (
     ProviderError,
     RateLimitError,
 )
+from .kilo import KiloProvider
 from .llamacpp import LlamaCppProvider
 from .lmstudio import LMStudioProvider
 from .nvidia_nim import NvidiaNimProvider
@@ -21,6 +22,7 @@ __all__ = [
     "BaseProvider",
     "DeepSeekProvider",
     "InvalidRequestError",
+    "KiloProvider",
     "LMStudioProvider",
     "LlamaCppProvider",
     "NvidiaNimProvider",

--- a/providers/kilo/__init__.py
+++ b/providers/kilo/__init__.py
@@ -1,0 +1,5 @@
+"""Kilo AI Gateway provider - OpenAI-compatible API for hundreds of models."""
+
+from .client import KILO_BASE_URL, KiloProvider
+
+__all__ = ["KILO_BASE_URL", "KiloProvider"]

--- a/providers/kilo/client.py
+++ b/providers/kilo/client.py
@@ -1,0 +1,29 @@
+"""Kilo AI Gateway provider implementation."""
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.openai_compat import OpenAICompatibleProvider
+
+from .request import build_request_body
+
+KILO_BASE_URL = "https://api.kilo.ai/api/gateway"
+
+
+class KiloProvider(OpenAICompatibleProvider):
+    """Kilo AI Gateway provider using OpenAI-compatible API."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="KILO",
+            base_url=config.base_url or KILO_BASE_URL,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(self, request: Any) -> dict:
+        """Internal helper for tests and shared building."""
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request),
+        )

--- a/providers/kilo/request.py
+++ b/providers/kilo/request.py
@@ -1,0 +1,32 @@
+"""Request builder for Kilo AI Gateway provider."""
+
+from typing import Any
+
+from loguru import logger
+
+from providers.common.message_converter import build_base_request_body
+
+KILO_DEFAULT_MAX_TOKENS = 81920
+
+
+def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+    """Build OpenAI-format request body from Anthropic request for Kilo."""
+    logger.debug(
+        "KILO_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+    body = build_base_request_body(
+        request_data,
+        include_thinking=thinking_enabled,
+        default_max_tokens=KILO_DEFAULT_MAX_TOKENS,
+        include_reasoning_for_openrouter=False,
+    )
+
+    logger.debug(
+        "KILO_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body


### PR DESCRIPTION
- Add kilo provider with OpenAI-compatible API endpoint
- Support 500+ models via Kilo Gateway at api.kilo.ai
- Add KILO_API_KEY and KILO_PROXY configuration options
- Update model validation to include 'kilo' as valid provider