### PR TITLE
fix: assign cls._instance in __new__ to complete the GlobalRateLimiter singleton

### DIFF
--- a/providers/rate_limit.py
+++ b/providers/rate_limit.py
@@ -34,6 +34,7 @@ class GlobalRateLimiter:
         if cls._instance is not None:
             return cls._instance
         instance = super().__new__(cls)
+        cls._instance = instance
         return instance
 
     def __init__(


### PR DESCRIPTION
## Summary

Fixes a bug in `providers/rate_limit.py` where `GlobalRateLimiter.__new__` never stored the newly-created instance in `cls._instance`.

## Problem

```python
def __new__(cls, *args, **kwargs):
    if cls._instance is not None:
        return cls._instance
    instance = super().__new__(cls)
    return instance   # ← cls._instance is never set!
```

Every call to the constructor creates a fresh object because the guard `if cls._instance is not None` always sees `None`. The singleton only appears to work because `get_instance()` sets `cls._instance` before returning — but any code that calls the constructor directly (e.g. in tests or advanced usage) receives a **separate, unregistered** rate-limiter, defeating the purpose of the singleton and potentially allowing multiple concurrent rate-limiters with independent state.

## Fix

```python
def __new__(cls, *args, **kwargs):
    if cls._instance is not None:
        return cls._instance
    instance = super().__new__(cls)
    cls._instance = instance   # ← store the new instance
    return instance
```

One-line addition that makes `__new__` behave correctly as a singleton factory.

Closes #154

Signed-off-by: Cocoon-Break <86288566+lingxiu58@users.noreply.github.com>