### PR TITLE
fix: assign cls._instance in GlobalRateLimiter.__new__ to preserve singleton

### DIFF
--- a/providers/rate_limit.py
+++ b/providers/rate_limit.py
@@ -34,6 +34,7 @@ class GlobalRateLimiter:
         if cls._instance is not None:
             return cls._instance
         instance = super().__new__(cls)
+        cls._instance = instance
         return instance
 
     def __init__(


### PR DESCRIPTION
## Fix GlobalRateLimiter singleton broken by missing cls._instance assignment

**Problem:** GlobalRateLimiter.__new__ never assigns the newly created instance back to cls._instance, so direct instantiation (bypassing get_instance()) creates a separate, unregistered object. This causes multiple independent rate limiter instances to run concurrently, defeating the singleton's purpose.

**Fix:** Add  before  in __new__.

**Test:** Verified the fix with:
```python
limiter_a = GlobalRateLimiter(rate_limit=10, rate_window=60, max_concurrency=3)
limiter_b = GlobalRateLimiter(rate_limit=999, rate_window=999, max_concurrency=999)
assert limiter_a is limiter_b  # True now (was False before the fix)
```

Fixes #154