### PR TITLE
feat: add provider fallback across providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,16 @@ MODEL_HAIKU="open_router/stepfun/step-3.5-flash:free"
 MODEL="nvidia_nim/z-ai/glm4.7"
 
 
+# Provider fallback (optional)
+# If the primary provider fails (server errors, rate limits, timeouts),
+# the proxy will automatically retry with the fallback provider.
+# Same format as MODEL_*/MODEL: provider_type/model/name
+FALLBACK_OPUS=""
+FALLBACK_SONNET=""
+FALLBACK_HAIKU=""
+FALLBACK=""
+
+
 # Thinking output
 # Global switch for provider reasoning requests and Claude thinking blocks.
 # Set false to suppress thinking across NIM, OpenRouter, LM Studio, and llama.cpp.

--- a/api/fallback.py
+++ b/api/fallback.py
@@ -1,0 +1,159 @@
+"""Provider fallback orchestration.
+
+When a primary provider fails before streaming begins, this module
+transparently retries with a configured fallback provider.
+"""
+
+from collections.abc import AsyncIterator
+
+import httpx
+import openai
+from loguru import logger
+
+from config.settings import Settings
+from providers.base import BaseProvider
+from providers.exceptions import (
+    APIError,
+    AuthenticationError,
+    InvalidRequestError,
+    OverloadedError,
+    RateLimitError,
+)
+
+from .dependencies import get_provider_for_type
+from .models.anthropic import MessagesRequest
+
+
+def is_fallback_trigger(error: Exception) -> bool:
+    """Return True if this error should trigger a provider fallback.
+
+    Only errors indicating the provider is unavailable or overloaded
+    trigger fallback. Client errors (bad request, auth) do not.
+    """
+    # Auth / bad request — configuration or request problem, not provider
+    if isinstance(error, (AuthenticationError, openai.AuthenticationError)):
+        return False
+    if isinstance(error, (InvalidRequestError, openai.BadRequestError)):
+        return False
+
+    # Rate limit after retries exhausted
+    if isinstance(error, (openai.RateLimitError, RateLimitError)):
+        return True
+
+    # Server errors / overloaded
+    if isinstance(error, OverloadedError):
+        return True
+    if isinstance(error, openai.InternalServerError):
+        return True
+    if isinstance(error, APIError) and error.status_code >= 500:
+        return True
+
+    # Connection failures
+    if isinstance(error, (httpx.ConnectError, httpx.ConnectTimeout)):
+        return True
+
+    # Read timeout
+    if isinstance(error, (httpx.ReadTimeout, TimeoutError)):
+        return True
+
+    # HTTPX status errors for 5xx / 429
+    if isinstance(error, httpx.HTTPStatusError):
+        status = error.response.status_code
+        return status >= 500 or status == 429
+
+    # Generic openai.APIError with 5xx or 429 status
+    if isinstance(error, openai.APIError):
+        status = getattr(error, "status_code", None)
+        return isinstance(status, int) and (status >= 500 or status == 429)
+
+    return False
+
+
+async def _passthrough(
+    provider: BaseProvider,
+    request: MessagesRequest,
+    input_tokens: int,
+    request_id: str | None,
+) -> AsyncIterator[str]:
+    """Yield all events from a provider with no fallback wrapping."""
+    async for event in provider.stream_response(
+        request, input_tokens, request_id=request_id
+    ):
+        yield event
+
+
+async def _stream_with_fallback_impl(
+    primary_provider: BaseProvider,
+    request: MessagesRequest,
+    input_tokens: int,
+    request_id: str | None,
+    fallback_model: str,
+) -> AsyncIterator[str]:
+    """Stream response, falling back to another provider on failure."""
+    try:
+        async for event in primary_provider.stream_response(
+            request, input_tokens, request_id=request_id
+        ):
+            yield event
+        return
+    except Exception as primary_error:
+        if not is_fallback_trigger(primary_error):
+            raise
+
+        logger.warning(
+            "FALLBACK: primary provider failed ({}), "
+            "trying fallback {} for request_id={}",
+            type(primary_error).__name__,
+            fallback_model,
+            request_id,
+        )
+
+    # Try fallback provider
+    fallback_provider_type = Settings.parse_provider_type(fallback_model)
+    fallback_provider = get_provider_for_type(fallback_provider_type)
+    fallback_model_name = Settings.parse_model_name(fallback_model)
+
+    original_model = request.model
+    request.model = fallback_model_name
+    try:
+        async for event in fallback_provider.stream_response(
+            request, input_tokens, request_id=request_id
+        ):
+            yield event
+    except Exception as fallback_error:
+        logger.error(
+            "FALLBACK: both primary and fallback ({}) failed for request_id={}. "
+            "Fallback error: {}",
+            fallback_provider_type,
+            request_id,
+            type(fallback_error).__name__,
+        )
+        raise
+    finally:
+        request.model = original_model
+
+
+def stream_with_fallback(
+    primary_provider: BaseProvider,
+    request: MessagesRequest,
+    input_tokens: int,
+    request_id: str | None,
+    *,
+    fallback_model: str | None,
+) -> AsyncIterator[str]:
+    """Stream response with optional provider fallback.
+
+    Tries the primary provider first. If its generator raises before
+    yielding any events and a fallback is configured for a triggering
+    error, the fallback provider is tried instead.
+
+    When no fallback is configured, this is a transparent passthrough
+    that preserves the original calling convention.
+    """
+    if fallback_model is None:
+        return primary_provider.stream_response(
+            request, input_tokens, request_id=request_id
+        )
+    return _stream_with_fallback_impl(
+        primary_provider, request, input_tokens, request_id, fallback_model
+    )

--- a/api/routes.py
+++ b/api/routes.py
@@ -12,6 +12,7 @@ from providers.common import get_user_facing_error_message
 from providers.exceptions import InvalidRequestError, ProviderError
 
 from .dependencies import get_provider_for_type, get_settings, require_api_key
+from .fallback import stream_with_fallback
 from .models.anthropic import MessagesRequest, TokenCountRequest
 from .models.responses import ModelResponse, ModelsListResponse, TokenCountResponse
 from .optimization_handlers import try_optimizations
@@ -91,12 +92,18 @@ async def create_message(
         )
         provider = get_provider_for_type(provider_type)
 
+        # Resolve fallback model (None if not configured)
+        fallback_model = settings.resolve_fallback(
+            request_data.original_model or request_data.model
+        )
+
         request_id = f"req_{uuid.uuid4().hex[:12]}"
         logger.info(
-            "API_REQUEST: request_id={} model={} messages={}",
+            "API_REQUEST: request_id={} model={} messages={} fallback={}",
             request_id,
             request_data.model,
             len(request_data.messages),
+            fallback_model or "none",
         )
         logger.debug("FULL_PAYLOAD [{}]: {}", request_id, request_data.model_dump())
 
@@ -104,10 +111,12 @@ async def create_message(
             request_data.messages, request_data.system, request_data.tools
         )
         return StreamingResponse(
-            provider.stream_response(
-                request_data,
+            stream_with_fallback(
+                primary_provider=provider,
+                request=request_data,
                 input_tokens=input_tokens,
                 request_id=request_id,
+                fallback_model=fallback_model,
             ),
             media_type="text/event-stream",
             headers={

--- a/config/settings.py
+++ b/config/settings.py
@@ -127,6 +127,16 @@ class Settings(BaseSettings):
     model_sonnet: str | None = Field(default=None, validation_alias="MODEL_SONNET")
     model_haiku: str | None = Field(default=None, validation_alias="MODEL_HAIKU")
 
+    # ==================== Provider Fallback ====================
+    # Optional fallback models tried when primary provider fails
+    # (server errors, rate limits, timeouts). Same provider/model format.
+    fallback_opus: str | None = Field(default=None, validation_alias="FALLBACK_OPUS")
+    fallback_sonnet: str | None = Field(
+        default=None, validation_alias="FALLBACK_SONNET"
+    )
+    fallback_haiku: str | None = Field(default=None, validation_alias="FALLBACK_HAIKU")
+    fallback: str | None = Field(default=None, validation_alias="FALLBACK")
+
     # ==================== Per-Provider Proxy ====================
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
@@ -217,6 +227,10 @@ class Settings(BaseSettings):
         "allowed_telegram_user_id",
         "discord_bot_token",
         "allowed_discord_channels",
+        "fallback_opus",
+        "fallback_sonnet",
+        "fallback_haiku",
+        "fallback",
         mode="before",
     )
     @classmethod
@@ -234,7 +248,16 @@ class Settings(BaseSettings):
             )
         return v
 
-    @field_validator("model", "model_opus", "model_sonnet", "model_haiku")
+    @field_validator(
+        "model",
+        "model_opus",
+        "model_sonnet",
+        "model_haiku",
+        "fallback",
+        "fallback_opus",
+        "fallback_sonnet",
+        "fallback_haiku",
+    )
     @classmethod
     def validate_model_format(cls, v: str | None) -> str | None:
         if v is None:
@@ -311,6 +334,20 @@ class Settings(BaseSettings):
         if "sonnet" in name_lower and self.model_sonnet is not None:
             return self.model_sonnet
         return self.model
+
+    def resolve_fallback(self, claude_model_name: str) -> str | None:
+        """Resolve a Claude model name to the configured fallback provider/model.
+
+        Returns None if no fallback is configured for this model tier.
+        """
+        name_lower = claude_model_name.lower()
+        if "opus" in name_lower and self.fallback_opus is not None:
+            return self.fallback_opus
+        if "haiku" in name_lower and self.fallback_haiku is not None:
+            return self.fallback_haiku
+        if "sonnet" in name_lower and self.fallback_sonnet is not None:
+            return self.fallback_sonnet
+        return self.fallback
 
     @staticmethod
     def parse_provider_type(model_string: str) -> str:

--- a/tests/api/test_fallback.py
+++ b/tests/api/test_fallback.py
@@ -1,0 +1,368 @@
+"""Tests for api/fallback.py — provider fallback orchestration."""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import openai
+import pytest
+
+from api.fallback import is_fallback_trigger, stream_with_fallback
+from providers.exceptions import (
+    APIError,
+    AuthenticationError,
+    InvalidRequestError,
+    OverloadedError,
+    RateLimitError,
+)
+
+# ---------------------------------------------------------------------------
+# is_fallback_trigger tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsFallbackTrigger:
+    """Test which errors trigger provider fallback."""
+
+    def test_rate_limit_error(self):
+        assert is_fallback_trigger(RateLimitError("rate limited")) is True
+
+    def test_openai_rate_limit_error(self):
+        err = openai.RateLimitError(
+            message="rate limited",
+            response=MagicMock(status_code=429),
+            body=None,
+        )
+        assert is_fallback_trigger(err) is True
+
+    def test_overloaded_error(self):
+        assert is_fallback_trigger(OverloadedError("overloaded")) is True
+
+    def test_openai_internal_server_error(self):
+        err = openai.InternalServerError(
+            message="internal error",
+            response=MagicMock(status_code=500),
+            body=None,
+        )
+        assert is_fallback_trigger(err) is True
+
+    def test_api_error_500(self):
+        assert is_fallback_trigger(APIError("fail", status_code=500)) is True
+
+    def test_api_error_502(self):
+        assert is_fallback_trigger(APIError("fail", status_code=502)) is True
+
+    def test_api_error_400_no_trigger(self):
+        assert is_fallback_trigger(APIError("fail", status_code=400)) is False
+
+    def test_connect_error(self):
+        assert is_fallback_trigger(httpx.ConnectError("refused")) is True
+
+    def test_connect_timeout(self):
+        assert is_fallback_trigger(httpx.ConnectTimeout("timeout")) is True
+
+    def test_read_timeout(self):
+        assert is_fallback_trigger(httpx.ReadTimeout("timeout")) is True
+
+    def test_timeout_error(self):
+        assert is_fallback_trigger(TimeoutError("timeout")) is True
+
+    def test_auth_error_no_trigger(self):
+        assert is_fallback_trigger(AuthenticationError("bad key")) is False
+
+    def test_openai_auth_error_no_trigger(self):
+        err = openai.AuthenticationError(
+            message="bad key",
+            response=MagicMock(status_code=401),
+            body=None,
+        )
+        assert is_fallback_trigger(err) is False
+
+    def test_invalid_request_no_trigger(self):
+        assert is_fallback_trigger(InvalidRequestError("bad request")) is False
+
+    def test_openai_bad_request_no_trigger(self):
+        err = openai.BadRequestError(
+            message="bad request",
+            response=MagicMock(status_code=400),
+            body=None,
+        )
+        assert is_fallback_trigger(err) is False
+
+    def test_httpx_status_error_500(self):
+        response = MagicMock()
+        response.status_code = 500
+        err = httpx.HTTPStatusError(
+            "server error", request=MagicMock(), response=response
+        )
+        assert is_fallback_trigger(err) is True
+
+    def test_httpx_status_error_429(self):
+        response = MagicMock()
+        response.status_code = 429
+        err = httpx.HTTPStatusError(
+            "rate limited", request=MagicMock(), response=response
+        )
+        assert is_fallback_trigger(err) is True
+
+    def test_httpx_status_error_400_no_trigger(self):
+        response = MagicMock()
+        response.status_code = 400
+        err = httpx.HTTPStatusError(
+            "bad request", request=MagicMock(), response=response
+        )
+        assert is_fallback_trigger(err) is False
+
+    def test_generic_exception_no_trigger(self):
+        assert is_fallback_trigger(ValueError("something")) is False
+
+    def test_generic_openai_api_error_500(self):
+        mock_resp = MagicMock(status_code=500)
+        err = openai.APIStatusError(
+            message="fail",
+            response=mock_resp,
+            body=None,
+        )
+        assert is_fallback_trigger(err) is True
+
+    def test_generic_openai_api_error_429(self):
+        mock_resp = MagicMock(status_code=429)
+        err = openai.APIStatusError(
+            message="fail",
+            response=mock_resp,
+            body=None,
+        )
+        assert is_fallback_trigger(err) is True
+
+
+# ---------------------------------------------------------------------------
+# stream_with_fallback tests
+# ---------------------------------------------------------------------------
+
+
+async def _collect(gen):
+    """Collect all items from an async generator."""
+    return [item async for item in gen]
+
+
+def _make_mock_request():
+    """Create a minimal mock MessagesRequest."""
+    req = MagicMock()
+    req.model = "test-model"
+    req.original_model = "claude-sonnet-4-20250514"
+    return req
+
+
+def _make_provider_that_yields(events):
+    """Create a mock provider whose stream_response yields the given events."""
+    provider = MagicMock()
+
+    async def _stream(*args, **kwargs):
+        for event in events:
+            yield event
+
+    provider.stream_response = _stream
+    return provider
+
+
+def _make_provider_that_raises(error):
+    """Create a mock provider whose stream_response raises the given error."""
+    provider = MagicMock()
+
+    async def _stream(*args, **kwargs):
+        raise error
+        yield  # make it a generator
+
+    provider.stream_response = _stream
+    return provider
+
+
+class TestStreamWithFallback:
+    """Test the stream_with_fallback orchestrator."""
+
+    @pytest.mark.asyncio
+    async def test_primary_succeeds_no_fallback_invoked(self):
+        primary = _make_provider_that_yields(["event1", "event2"])
+        request = _make_mock_request()
+
+        events = await _collect(
+            stream_with_fallback(primary, request, 100, "req_123", fallback_model=None)
+        )
+        assert events == ["event1", "event2"]
+
+    @pytest.mark.asyncio
+    async def test_primary_succeeds_fallback_configured_but_not_used(self):
+        primary = _make_provider_that_yields(["event1", "event2"])
+        request = _make_mock_request()
+
+        events = await _collect(
+            stream_with_fallback(
+                primary,
+                request,
+                100,
+                "req_123",
+                fallback_model="open_router/fallback-model",
+            )
+        )
+        assert events == ["event1", "event2"]
+
+    @pytest.mark.asyncio
+    async def test_primary_fails_no_fallback_configured(self):
+        primary = _make_provider_that_raises(httpx.ConnectError("refused"))
+        request = _make_mock_request()
+
+        with pytest.raises(httpx.ConnectError):
+            await _collect(
+                stream_with_fallback(
+                    primary, request, 100, "req_123", fallback_model=None
+                )
+            )
+
+    @pytest.mark.asyncio
+    async def test_primary_fails_non_trigger_error_no_fallback(self):
+        primary = _make_provider_that_raises(AuthenticationError("bad key"))
+        request = _make_mock_request()
+
+        with pytest.raises(AuthenticationError):
+            await _collect(
+                stream_with_fallback(
+                    primary,
+                    request,
+                    100,
+                    "req_123",
+                    fallback_model="open_router/fallback-model",
+                )
+            )
+
+    @pytest.mark.asyncio
+    @patch("api.fallback.get_provider_for_type")
+    async def test_primary_fails_fallback_succeeds(self, mock_get_provider):
+        primary = _make_provider_that_raises(httpx.ConnectError("refused"))
+        fallback = _make_provider_that_yields(["fb_event1", "fb_event2"])
+        mock_get_provider.return_value = fallback
+
+        request = _make_mock_request()
+
+        events = await _collect(
+            stream_with_fallback(
+                primary,
+                request,
+                100,
+                "req_123",
+                fallback_model="open_router/fallback-model",
+            )
+        )
+        assert events == ["fb_event1", "fb_event2"]
+        mock_get_provider.assert_called_once_with("open_router")
+
+    @pytest.mark.asyncio
+    @patch("api.fallback.get_provider_for_type")
+    async def test_primary_fails_fallback_also_fails(self, mock_get_provider):
+        primary = _make_provider_that_raises(httpx.ConnectError("refused"))
+        fallback = _make_provider_that_raises(httpx.ReadTimeout("timeout"))
+        mock_get_provider.return_value = fallback
+
+        request = _make_mock_request()
+
+        with pytest.raises(httpx.ReadTimeout):
+            await _collect(
+                stream_with_fallback(
+                    primary,
+                    request,
+                    100,
+                    "req_123",
+                    fallback_model="open_router/fallback-model",
+                )
+            )
+
+    @pytest.mark.asyncio
+    @patch("api.fallback.get_provider_for_type")
+    async def test_model_restored_after_fallback(self, mock_get_provider):
+        primary = _make_provider_that_raises(httpx.ConnectError("refused"))
+        fallback = _make_provider_that_yields(["fb_event"])
+        mock_get_provider.return_value = fallback
+
+        request = _make_mock_request()
+        original_model = request.model
+
+        await _collect(
+            stream_with_fallback(
+                primary,
+                request,
+                100,
+                "req_123",
+                fallback_model="open_router/fallback-model",
+            )
+        )
+        assert request.model == original_model
+
+    @pytest.mark.asyncio
+    @patch("api.fallback.get_provider_for_type")
+    async def test_model_restored_after_fallback_failure(self, mock_get_provider):
+        primary = _make_provider_that_raises(httpx.ConnectError("refused"))
+        fallback = _make_provider_that_raises(httpx.ConnectError("also refused"))
+        mock_get_provider.return_value = fallback
+
+        request = _make_mock_request()
+        original_model = request.model
+
+        with pytest.raises(httpx.ConnectError):
+            await _collect(
+                stream_with_fallback(
+                    primary,
+                    request,
+                    100,
+                    "req_123",
+                    fallback_model="open_router/fallback-model",
+                )
+            )
+        assert request.model == original_model
+
+    @pytest.mark.asyncio
+    @patch("api.fallback.get_provider_for_type")
+    async def test_fallback_model_name_set_during_fallback(self, mock_get_provider):
+        """Verify the request.model is set to the fallback model name during streaming."""
+        captured_model = None
+
+        provider = MagicMock()
+
+        async def _capture_stream(request, *args, **kwargs):
+            nonlocal captured_model
+            captured_model = request.model
+            yield "event"
+
+        provider.stream_response = _capture_stream
+
+        primary = _make_provider_that_raises(httpx.ConnectError("refused"))
+        mock_get_provider.return_value = provider
+
+        request = _make_mock_request()
+        await _collect(
+            stream_with_fallback(
+                primary,
+                request,
+                100,
+                "req_123",
+                fallback_model="open_router/my-fallback/model",
+            )
+        )
+        assert captured_model == "my-fallback/model"
+
+    @pytest.mark.asyncio
+    @patch("api.fallback.get_provider_for_type")
+    async def test_rate_limit_triggers_fallback(self, mock_get_provider):
+        primary = _make_provider_that_raises(RateLimitError("429"))
+        fallback = _make_provider_that_yields(["fb_event"])
+        mock_get_provider.return_value = fallback
+
+        request = _make_mock_request()
+        events = await _collect(
+            stream_with_fallback(
+                primary,
+                request,
+                100,
+                "req_123",
+                fallback_model="nvidia_nim/backup-model",
+            )
+        )
+        assert events == ["fb_event"]
+        mock_get_provider.assert_called_once_with("nvidia_nim")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -555,3 +555,134 @@ class TestPerModelMapping:
         assert Settings.parse_model_name("deepseek/deepseek-chat") == "deepseek-chat"
         assert Settings.parse_model_name("lmstudio/qwen") == "qwen"
         assert Settings.parse_model_name("llamacpp/model") == "model"
+
+
+class TestFallbackSettings:
+    """Test fallback model fields and resolve_fallback()."""
+
+    def test_fallback_fields_default_none(self):
+        """Fallback fields default to None."""
+        from config.settings import Settings
+
+        s = Settings()
+        assert s.fallback_opus is None
+        assert s.fallback_sonnet is None
+        assert s.fallback_haiku is None
+        assert s.fallback is None
+
+    def test_fallback_from_env(self, monkeypatch):
+        """FALLBACK env var is loaded."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("FALLBACK", "open_router/fallback-model")
+        s = Settings()
+        assert s.fallback == "open_router/fallback-model"
+
+    def test_fallback_opus_from_env(self, monkeypatch):
+        """FALLBACK_OPUS env var is loaded."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("FALLBACK_OPUS", "open_router/opus-fallback")
+        s = Settings()
+        assert s.fallback_opus == "open_router/opus-fallback"
+
+    def test_fallback_empty_string_to_none(self, monkeypatch):
+        """Empty FALLBACK env var is converted to None."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("FALLBACK", "")
+        s = Settings()
+        assert s.fallback is None
+
+    def test_fallback_invalid_provider_raises(self, monkeypatch):
+        """FALLBACK with invalid provider prefix raises ValidationError."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("FALLBACK", "bad_provider/model")
+        with pytest.raises(ValidationError, match="Invalid provider"):
+            Settings()
+
+    def test_fallback_no_slash_raises(self, monkeypatch):
+        """FALLBACK without provider prefix raises ValidationError."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("FALLBACK", "noprefix")
+        with pytest.raises(ValidationError, match="provider type"):
+            Settings()
+
+    def test_resolve_fallback_opus(self):
+        """resolve_fallback returns fallback_opus for opus models."""
+        from config.settings import Settings
+
+        s = Settings()
+        s.fallback_opus = "open_router/opus-fallback"
+        assert (
+            s.resolve_fallback("claude-opus-4-20250514") == "open_router/opus-fallback"
+        )
+
+    def test_resolve_fallback_sonnet(self):
+        """resolve_fallback returns fallback_sonnet for sonnet models."""
+        from config.settings import Settings
+
+        s = Settings()
+        s.fallback_sonnet = "nvidia_nim/sonnet-fallback"
+        assert (
+            s.resolve_fallback("claude-sonnet-4-20250514")
+            == "nvidia_nim/sonnet-fallback"
+        )
+
+    def test_resolve_fallback_haiku(self):
+        """resolve_fallback returns fallback_haiku for haiku models."""
+        from config.settings import Settings
+
+        s = Settings()
+        s.fallback_haiku = "deepseek/haiku-fallback"
+        assert (
+            s.resolve_fallback("claude-3-haiku-20240307") == "deepseek/haiku-fallback"
+        )
+
+    def test_resolve_fallback_global(self):
+        """resolve_fallback returns global fallback when tier-specific not set."""
+        from config.settings import Settings
+
+        s = Settings()
+        s.fallback = "open_router/global-fallback"
+        assert (
+            s.resolve_fallback("claude-opus-4-20250514")
+            == "open_router/global-fallback"
+        )
+        assert (
+            s.resolve_fallback("claude-sonnet-4-20250514")
+            == "open_router/global-fallback"
+        )
+
+    def test_resolve_fallback_tier_overrides_global(self):
+        """Tier-specific fallback takes precedence over global."""
+        from config.settings import Settings
+
+        s = Settings()
+        s.fallback = "open_router/global-fallback"
+        s.fallback_opus = "nvidia_nim/opus-specific"
+        assert (
+            s.resolve_fallback("claude-opus-4-20250514") == "nvidia_nim/opus-specific"
+        )
+        assert (
+            s.resolve_fallback("claude-sonnet-4-20250514")
+            == "open_router/global-fallback"
+        )
+
+    def test_resolve_fallback_none_when_unconfigured(self):
+        """resolve_fallback returns None when nothing configured."""
+        from config.settings import Settings
+
+        s = Settings()
+        assert s.resolve_fallback("claude-opus-4-20250514") is None
+        assert s.resolve_fallback("claude-sonnet-4-20250514") is None
+
+    def test_resolve_fallback_case_insensitive(self):
+        """Fallback classification is case-insensitive."""
+        from config.settings import Settings
+
+        s = Settings()
+        s.fallback_opus = "open_router/opus-fallback"
+        assert s.resolve_fallback("Claude-OPUS-4") == "open_router/opus-fallback"


### PR DESCRIPTION
When a primary provider fails before streaming starts (429 after retries, 500, connection error, timeout), the proxy automatically tries a configured fallback provider. Fully opt-in via FALLBACK_* env vars.

- Add FALLBACK_OPUS, FALLBACK_SONNET, FALLBACK_HAIKU, FALLBACK settings
- Add resolve_fallback() to Settings mirroring resolve_model() pattern
- Add api/fallback.py with is_fallback_trigger() and stream_with_fallback()
- Wire fallback into create_message() route handler
- Auth errors (401) and bad requests (400) do NOT trigger fallback
- Zero behavior change when FALLBACK_* vars are not configured
- 24 new tests covering error classification and fallback orchestration