### PR TITLE
Add Dependabot config for uv dependencies and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Adds a Dependabot configuration to automate weekly update PRs for:

- `uv`-managed Python dependencies
- GitHub Actions used in CI workflows

## Why

This repository already relies on pinned dependency state via `uv.lock` and pinned GitHub Action revisions in CI. Adding Dependabot helps keep both current with small, reviewable update PRs instead of larger manual catch-up updates.

## What this changes

- Adds `.github/dependabot.yml`
- Configures weekly version update checks for the repo root
- Groups minor and patch dependency updates to reduce PR noise
- Enables automatic update PRs for GitHub Actions references in workflows

## Used `uv` instead of `pip`

This project uses `uv` directly (`uv.lock`, `uv run`, and repo instructions based on `uv`), so configuring Dependabot with the `uv` ecosystem matches the repository’s actual package management workflow more closely than a generic `pip` entry.

## Risk

Low. This is a configuration only change and does not affect application runtime behavior .
