### PR TITLE
Add local Codex CLI provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,16 @@ LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 
+# Codex CLI Config (local/dev provider, no API key required)
+CODEX_CLI_BIN="codex"
+CODEX_WORKSPACE=""
+CODEX_TIMEOUT="300"
+CODEX_MODEL=""
+
+
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp"
+# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "codex_cli"
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=

--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ The proxy also exposes Claude-compatible probe routes: `GET /v1/models`, `POST /
 | **DeepSeek**   | Usage-based  | Varies     | Direct access to DeepSeek chat/reasoner |
 | **LM Studio**  | Free (local) | Unlimited  | Privacy, offline use, no rate limits |
 | **llama.cpp**  | Free (local) | Unlimited  | Lightweight local inference engine   |
+| **Codex CLI**  | Free/Paid via local login | Local CLI | Local/dev text-only Codex CLI bridge |
 
 Models use a prefix format: `provider_prefix/model/name`. An invalid prefix causes an error.
 
@@ -346,6 +347,7 @@ Models use a prefix format: `provider_prefix/model/name`. An invalid prefix caus
 | DeepSeek   | `deepseek/...`    | `DEEPSEEK_API_KEY`   | `api.deepseek.com`            |
 | LM Studio  | `lmstudio/...`    | (none)               | `localhost:1234/v1`           |
 | llama.cpp  | `llamacpp/...`    | (none)               | `localhost:8080/v1`           |
+| Codex CLI  | `codex_cli/...`   | (none)               | local `codex exec` binary     |
 
 <details>
 <summary><b>NVIDIA NIM models</b></summary>
@@ -411,6 +413,24 @@ Run models locally using `llama-server`. Ensure you have a tool-capable GGUF. Se
 
 See the Unsloth docs for detailed instructions and capable models:
 [https://unsloth.ai/docs/models/qwen3.5#qwen3.5-small-0.8b-2b-4b-9b](https://unsloth.ai/docs/models/qwen3.5#qwen3.5-small-0.8b-2b-4b-9b)
+
+</details>
+
+<details>
+<summary><b>Codex CLI provider</b></summary>
+
+Use an already-authenticated local Codex CLI as a local/dev backend:
+
+```dotenv
+MODEL="codex_cli/default"
+CODEX_CLI_BIN="codex"
+CODEX_WORKSPACE="/home/jnibarger"
+CODEX_TIMEOUT="300"
+# Optional: pass a Codex model with `codex exec -m ...`
+CODEX_MODEL=""
+```
+
+This provider invokes `codex exec --json` only. It does not use `OPENAI_API_KEY`, does not register an OpenAI API provider, and does not read or export hidden Codex auth tokens. MVP scope is text responses only. Claude tool-use blocks, image input, and structured tool calls are not bridged through this adapter.
 
 </details>
 

--- a/config/env.example
+++ b/config/env.example
@@ -18,9 +18,16 @@ LM_STUDIO_BASE_URL="http://localhost:1234/v1"
 LLAMACPP_BASE_URL="http://localhost:8080/v1"
 
 
+# Codex CLI Config (local/dev provider, no API key required)
+CODEX_CLI_BIN="codex"
+CODEX_WORKSPACE=""
+CODEX_TIMEOUT="300"
+CODEX_MODEL=""
+
+
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp"
+# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "codex_cli"
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=

--- a/config/provider_ids.py
+++ b/config/provider_ids.py
@@ -14,4 +14,5 @@ SUPPORTED_PROVIDER_IDS: tuple[str, ...] = (
     "deepseek",
     "lmstudio",
     "llamacpp",
+    "codex_cli",
 )

--- a/config/settings.py
+++ b/config/settings.py
@@ -117,6 +117,12 @@ class Settings(BaseSettings):
         validation_alias="LLAMACPP_BASE_URL",
     )
 
+    # ==================== Codex CLI Config ====================
+    codex_cli_bin: str = Field(default="codex", validation_alias="CODEX_CLI_BIN")
+    codex_workspace: str = Field(default="", validation_alias="CODEX_WORKSPACE")
+    codex_timeout: float = Field(default=300.0, validation_alias="CODEX_TIMEOUT")
+    codex_model: str = Field(default="", validation_alias="CODEX_MODEL")
+
     # ==================== Model ====================
     # All Claude model requests are mapped to this single model (fallback)
     # Format: provider_type/model/name

--- a/providers/codex_cli/__init__.py
+++ b/providers/codex_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Local Codex CLI provider."""
+
+from .client import CodexCliProvider
+
+__all__ = ["CodexCliProvider"]

--- a/providers/codex_cli/client.py
+++ b/providers/codex_cli/client.py
@@ -1,0 +1,198 @@
+"""Local Codex CLI provider.
+
+This adapter intentionally uses only the installed `codex` binary. It does not
+read Codex auth files and does not use OpenAI API keys or SDK clients.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator, Sequence
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from core.anthropic import SSEBuilder, append_request_id
+from providers.base import BaseProvider, ProviderConfig
+
+from .request import build_prompt
+from .response import parse_jsonl_text
+
+
+class CodexCliProvider(BaseProvider):
+    """Provider that shells out to `codex exec` for local/dev text responses."""
+
+    def __init__(
+        self,
+        config: ProviderConfig,
+        *,
+        codex_bin: str = "codex",
+        workspace: str = "",
+        timeout: float = 300.0,
+        codex_model: str = "",
+    ):
+        super().__init__(config)
+        self.codex_bin = codex_bin or "codex"
+        self.workspace = workspace
+        self.timeout = timeout
+        self.codex_model = codex_model
+
+    async def cleanup(self) -> None:
+        """No persistent resources are held by the CLI adapter."""
+
+    def _cwd(self) -> str:
+        return self.workspace or str(Path.cwd())
+
+    def build_command(self, _prompt: str, request_model: str = "") -> list[str]:
+        """Build the Codex CLI command using only supported `codex exec` flags."""
+        cwd = self._cwd()
+        command = [
+            self.codex_bin,
+            "exec",
+            "--json",
+            "--color",
+            "never",
+            "--skip-git-repo-check",
+            "-C",
+            cwd,
+        ]
+        model = self.codex_model.strip() or (
+            request_model if request_model and request_model != "default" else ""
+        )
+        if model:
+            command.extend(["-m", model])
+        command.append("-")
+        return command
+
+    async def _start_process(
+        self, command: Sequence[str], cwd: str
+    ) -> asyncio.subprocess.Process:
+        return await asyncio.create_subprocess_exec(
+            *command,
+            cwd=cwd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+    async def _terminate(self, process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        process.kill()
+        await process.wait()
+
+    async def _run_codex(
+        self, command: Sequence[str], cwd: str, prompt: str = ""
+    ) -> AsyncIterator[str]:
+        process = await self._start_process(command, cwd)
+        stderr_task = asyncio.create_task(
+            process.stderr.read() if process.stderr else _empty_bytes()
+        )
+        emitted_text = False
+        try:
+            async with asyncio.timeout(self.timeout):
+                await _write_stdin_prompt(process, prompt)
+                if process.stdout is not None:
+                    async for raw_line in process.stdout:
+                        line = raw_line.decode(errors="replace").strip()
+                        if text := parse_jsonl_text(line):
+                            emitted_text = True
+                            yield text
+                return_code = await process.wait()
+        except TimeoutError as e:
+            await self._terminate(process)
+            stderr = await _task_bytes(stderr_task)
+            detail = stderr.decode(errors="replace").strip()
+            msg = f"Codex CLI timed out after {self.timeout:g}s"
+            if detail:
+                msg = f"{msg}: {detail}"
+            raise RuntimeError(msg) from e
+        except asyncio.CancelledError:
+            await self._terminate(process)
+            raise
+
+        stderr = (await _task_bytes(stderr_task)).decode(errors="replace").strip()
+        if return_code != 0:
+            msg = f"Codex CLI exited with code {return_code}"
+            if stderr:
+                msg = f"{msg}: {stderr}"
+            raise RuntimeError(msg)
+        if stderr and not emitted_text:
+            raise RuntimeError(f"Codex CLI produced no text output: {stderr}")
+        if stderr:
+            logger.debug("CODEX_CLI_STDERR: {}", stderr)
+
+    async def stream_response(
+        self,
+        request: Any,
+        input_tokens: int = 0,
+        *,
+        request_id: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream Codex CLI stdout as Anthropic-compatible text SSE."""
+        message_id = f"msg_{uuid.uuid4()}"
+        sse = SSEBuilder(message_id, request.model, input_tokens)
+        prompt = build_prompt(request)
+        command = self.build_command(prompt, request_model=request.model)
+        req_tag = f" request_id={request_id}" if request_id else ""
+        logger.info(
+            "CODEX_CLI_STREAM:{} command={} cwd={}", req_tag, command[:8], self._cwd()
+        )
+
+        yield sse.message_start()
+        emitted_text = False
+        error_occurred = False
+        try:
+            for event in sse.ensure_text_block():
+                yield event
+            async for text in self._run_codex(command, self._cwd(), prompt):
+                emitted_text = True
+                yield sse.emit_text_delta(text)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            error_occurred = True
+            logger.error("CODEX_CLI_ERROR:{} {}", req_tag, e)
+            for event in sse.close_content_blocks():
+                yield event
+            error_message = append_request_id(str(e), request_id)
+            for event in sse.emit_error(error_message):
+                yield event
+
+        if not emitted_text and not error_occurred:
+            yield sse.emit_text_delta(" ")
+        for event in sse.close_all_blocks():
+            yield event
+        yield sse.message_delta("end_turn", sse.estimate_output_tokens())
+        yield sse.message_stop()
+
+
+async def _empty_bytes() -> bytes:
+    return b""
+
+
+async def _write_stdin_prompt(process: asyncio.subprocess.Process, prompt: str) -> None:
+    if process.stdin is None:
+        return
+    try:
+        if prompt:
+            process.stdin.write(prompt.encode())
+            await process.stdin.drain()
+    except BrokenPipeError, ConnectionResetError:
+        pass
+    finally:
+        process.stdin.close()
+        wait_closed = getattr(process.stdin, "wait_closed", None)
+        if wait_closed is not None:
+            with suppress(BrokenPipeError, ConnectionResetError):
+                await wait_closed()
+
+
+async def _task_bytes(task: asyncio.Task[bytes]) -> bytes:
+    try:
+        return await task
+    except Exception:
+        return b""

--- a/providers/codex_cli/request.py
+++ b/providers/codex_cli/request.py
@@ -1,0 +1,82 @@
+"""Build plain-text prompts for the local Codex CLI provider."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return str(content)
+
+    parts: list[str] = []
+    for block in content:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            parts.append(getattr(block, "text", ""))
+        elif block_type == "tool_result":
+            tool_id = getattr(block, "tool_use_id", "")
+            result = getattr(block, "content", "")
+            parts.append(f"[tool_result {tool_id}] {result}")
+        elif block_type == "tool_use":
+            name = getattr(block, "name", "")
+            tool_input = getattr(block, "input", {})
+            parts.append(
+                f"[tool_use requested by assistant: {name}] "
+                f"{json.dumps(tool_input, ensure_ascii=False)}"
+            )
+        elif block_type == "thinking":
+            parts.append(
+                f"[assistant thinking omitted] {getattr(block, 'thinking', '')}"
+            )
+        elif block_type == "redacted_thinking":
+            parts.append("[redacted thinking omitted]")
+        elif block_type == "image":
+            parts.append("[image input omitted: codex_cli adapter supports text only]")
+        else:
+            parts.append(str(block))
+    return "\n".join(part for part in parts if part)
+
+
+def _system_to_text(system: Any) -> str:
+    if system is None:
+        return ""
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        return "\n".join(
+            getattr(block, "text", str(block)) for block in system if block is not None
+        )
+    return str(system)
+
+
+def build_prompt(request: Any) -> str:
+    """Convert an Anthropic Messages request into a single Codex prompt string."""
+    sections: list[str] = []
+    system_text = _system_to_text(getattr(request, "system", None)).strip()
+    if system_text:
+        sections.append(f"System instructions:\n{system_text}")
+
+    tools = getattr(request, "tools", None) or []
+    if tools:
+        tool_names = ", ".join(getattr(tool, "name", "unknown") for tool in tools)
+        sections.append(
+            "Adapter note: Claude tool-use blocks are not supported by the "
+            "codex_cli provider. Respond with plain text only; do not emit "
+            f"structured tool calls. Requested tool names: {tool_names}."
+        )
+
+    messages = getattr(request, "messages", [])
+    transcript: list[str] = []
+    for message in messages:
+        role = getattr(message, "role", "user")
+        text = _content_to_text(getattr(message, "content", ""))
+        transcript.append(f"{role}:\n{text}")
+    if transcript:
+        sections.append("Conversation:\n" + "\n\n".join(transcript))
+
+    sections.append("Assistant: respond with plain text only.")
+    return "\n\n".join(sections).strip()

--- a/providers/codex_cli/response.py
+++ b/providers/codex_cli/response.py
@@ -1,0 +1,27 @@
+"""Response helpers for the local Codex CLI provider."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def text_from_json_event(event: dict[str, Any]) -> str:
+    """Extract user-visible text from one `codex exec --json` event."""
+    if event.get("type") == "item.completed":
+        item = event.get("item")
+        if isinstance(item, dict) and item.get("type") == "agent_message":
+            text = item.get("text")
+            return text if isinstance(text, str) else ""
+    return ""
+
+
+def parse_jsonl_text(line: str) -> str:
+    """Parse a Codex JSONL line and return assistant text, if any."""
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(event, dict):
+        return ""
+    return text_from_json_event(event)

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -18,7 +18,7 @@ from providers.defaults import (
 )
 from providers.exceptions import AuthenticationError, UnknownProviderTypeError
 
-TransportType = Literal["openai_chat", "anthropic_messages"]
+TransportType = Literal["openai_chat", "anthropic_messages", "local_cli"]
 ProviderFactory = Callable[[ProviderConfig, Settings], BaseProvider]
 
 
@@ -88,6 +88,12 @@ PROVIDER_DESCRIPTORS: dict[str, ProviderDescriptor] = {
         proxy_attr="llamacpp_proxy",
         capabilities=("chat", "streaming", "tools", "native_anthropic", "local"),
     ),
+    "codex_cli": ProviderDescriptor(
+        provider_id="codex_cli",
+        transport_type="local_cli",
+        static_credential="codex-cli",
+        capabilities=("chat", "streaming", "local", "text_only"),
+    ),
 }
 
 
@@ -121,12 +127,25 @@ def _create_llamacpp(config: ProviderConfig, settings: Settings) -> BaseProvider
     return LlamaCppProvider(config)
 
 
+def _create_codex_cli(config: ProviderConfig, settings: Settings) -> BaseProvider:
+    from providers.codex_cli import CodexCliProvider
+
+    return CodexCliProvider(
+        config,
+        codex_bin=settings.codex_cli_bin,
+        workspace=settings.codex_workspace,
+        timeout=settings.codex_timeout,
+        codex_model=settings.codex_model,
+    )
+
+
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
     "deepseek": _create_deepseek,
     "lmstudio": _create_lmstudio,
     "llamacpp": _create_llamacpp,
+    "codex_cli": _create_codex_cli,
 }
 
 if set(PROVIDER_DESCRIPTORS) != set(SUPPORTED_PROVIDER_IDS) or set(

--- a/tests/api/test_model_router.py
+++ b/tests/api/test_model_router.py
@@ -96,3 +96,20 @@ def test_model_router_logs_mapping(settings):
     assert "MODEL MAPPING" in args[0]
     assert args[1] == "claude-2.1"
     assert args[2] == "fallback-model"
+
+
+def test_model_router_maps_claude_model_to_codex_cli_provider_model(settings):
+    settings.model = "codex_cli/default"
+
+    routed = ModelRouter(settings).resolve_messages_request(
+        MessagesRequest(
+            model="claude-sonnet-4-20250514",
+            max_tokens=100,
+            messages=[Message(role="user", content="hello")],
+        )
+    )
+
+    assert routed.request.model == "default"
+    assert routed.resolved.provider_id == "codex_cli"
+    assert routed.resolved.provider_model == "default"
+    assert routed.resolved.provider_model_ref == "codex_cli/default"

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -568,3 +568,46 @@ class TestPerModelMapping:
         assert Settings.parse_model_name("deepseek/deepseek-chat") == "deepseek-chat"
         assert Settings.parse_model_name("lmstudio/qwen") == "qwen"
         assert Settings.parse_model_name("llamacpp/model") == "model"
+
+
+def test_codex_cli_model_prefix_validates(monkeypatch):
+    """MODEL=codex_cli/<model> is accepted as a local CLI provider prefix."""
+    from config.settings import Settings
+
+    monkeypatch.setitem(Settings.model_config, "env_file", ())
+    monkeypatch.setenv("MODEL", "codex_cli/default")
+
+    settings = Settings()
+
+    assert settings.model == "codex_cli/default"
+    assert settings.provider_type == "codex_cli"
+    assert settings.model_name == "default"
+
+
+def test_codex_cli_settings_from_env(monkeypatch):
+    """CODEX_* env vars are loaded into settings."""
+    from config.settings import Settings
+
+    monkeypatch.setitem(Settings.model_config, "env_file", ())
+    monkeypatch.setenv("CODEX_CLI_BIN", "/opt/bin/codex")
+    monkeypatch.setenv("CODEX_WORKSPACE", "/tmp/codex-work")
+    monkeypatch.setenv("CODEX_TIMEOUT", "12.5")
+    monkeypatch.setenv("CODEX_MODEL", "gpt-5.2-codex")
+
+    settings = Settings()
+
+    assert settings.codex_cli_bin == "/opt/bin/codex"
+    assert settings.codex_workspace == "/tmp/codex-work"
+    assert settings.codex_timeout == 12.5
+    assert settings.codex_model == "gpt-5.2-codex"
+
+
+def test_unsupported_model_provider_prefix_still_fails(monkeypatch):
+    """Unsupported provider prefixes still fail validation."""
+    from config.settings import Settings
+
+    monkeypatch.setitem(Settings.model_config, "env_file", ())
+    monkeypatch.setenv("MODEL", "unsupported/gpt-5.2-codex")
+
+    with pytest.raises(ValidationError, match="Invalid provider"):
+        Settings()

--- a/tests/contracts/test_feature_manifest.py
+++ b/tests/contracts/test_feature_manifest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from messaging.platforms.factory import create_messaging_platform
 from providers.base import BaseProvider
+from providers.codex_cli import CodexCliProvider
 from providers.deepseek import DeepSeekProvider
 from providers.llamacpp import LlamaCppProvider
 from providers.lmstudio import LMStudioProvider
@@ -71,6 +72,7 @@ def test_provider_and_platform_registries_include_advertised_builtins() -> None:
         "deepseek": DeepSeekProvider,
         "lmstudio": LMStudioProvider,
         "llamacpp": LlamaCppProvider,
+        "codex_cli": CodexCliProvider,
     }
     for provider_class in provider_classes.values():
         assert issubclass(provider_class, BaseProvider)

--- a/tests/providers/test_codex_cli.py
+++ b/tests/providers/test_codex_cli.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from providers.base import ProviderConfig
+from providers.codex_cli import CodexCliProvider
+
+
+class EmptyStdout:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        raise StopAsyncIteration
+
+
+class NeverStdout:
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        await asyncio.sleep(999)
+        raise StopAsyncIteration
+
+
+class FakeStderr:
+    def __init__(self, data: bytes = b""):
+        self._data = data
+
+    async def read(self) -> bytes:
+        return self._data
+
+
+class FakeStdin:
+    def __init__(self) -> None:
+        self.data = b""
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.data += data
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+class FakeProcess:
+    def __init__(self, *, stdout: Any = None, stderr: bytes = b"", returncode: int = 0):
+        self.stdin = FakeStdin()
+        self.stdout = stdout if stdout is not None else EmptyStdout()
+        self.stderr = FakeStderr(stderr)
+        self.returncode: int | None = None
+        self._final_returncode = returncode
+        self.killed = False
+
+    async def wait(self) -> int:
+        self.returncode = self._final_returncode
+        return self._final_returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+
+def provider(**kwargs: Any) -> CodexCliProvider:
+    return CodexCliProvider(ProviderConfig(api_key="codex-cli"), **kwargs)
+
+
+def request(model: str = "default") -> SimpleNamespace:
+    return SimpleNamespace(
+        model=model,
+        system="You are concise.",
+        messages=[SimpleNamespace(role="user", content="Say hello")],
+        tools=None,
+        thinking=None,
+    )
+
+
+def test_command_construction_uses_codex_cli_bin() -> None:
+    p = provider(codex_bin="/custom/codex", workspace="/tmp/work", codex_model="")
+
+    command = p.build_command("hello", request_model="default")
+
+    assert command[:8] == [
+        "/custom/codex",
+        "exec",
+        "--json",
+        "--color",
+        "never",
+        "--skip-git-repo-check",
+        "-C",
+        "/tmp/work",
+    ]
+    assert command[-1] == "-"
+    assert "hello" not in command
+
+
+@pytest.mark.asyncio
+async def test_subprocess_invoked_without_shell_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_create_subprocess_exec(*args: str, **kwargs: Any) -> FakeProcess:
+        calls.append({"args": args, "kwargs": kwargs})
+        return FakeProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    p = provider(codex_bin="codex-test", workspace="/tmp")
+
+    assert [text async for text in p._run_codex(p.build_command("hello"), "/tmp")] == []
+
+    assert calls
+    assert calls[0]["args"][0] == "codex-test"
+    assert "shell" not in calls[0]["kwargs"]
+    assert calls[0]["kwargs"]["stdin"] == asyncio.subprocess.PIPE
+
+
+@pytest.mark.asyncio
+async def test_prompt_is_written_to_stdin(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = FakeProcess()
+    p = provider(workspace="/tmp")
+
+    async def fake_start(command: list[str], cwd: str) -> FakeProcess:
+        return fake
+
+    monkeypatch.setattr(p, "_start_process", fake_start)
+
+    assert [
+        text
+        async for text in p._run_codex(
+            p.build_command("large prompt"), "/tmp", "large prompt"
+        )
+    ] == []
+
+    assert fake.stdin.data == b"large prompt"
+    assert fake.stdin.closed is True
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = FakeProcess(stdout=NeverStdout(), stderr=b"still running", returncode=0)
+    p = provider(workspace="/tmp", timeout=0.01)
+
+    async def fake_start(command: list[str], cwd: str) -> FakeProcess:
+        return fake
+
+    monkeypatch.setattr(p, "_start_process", fake_start)
+
+    with pytest.raises(RuntimeError, match="timed out"):
+        _ = [text async for text in p._run_codex(p.build_command("hello"), "/tmp")]
+
+    assert fake.killed is True
+
+
+@pytest.mark.asyncio
+async def test_stderr_becomes_visible_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    p = provider(workspace="/tmp")
+
+    async def fake_start(command: list[str], cwd: str) -> FakeProcess:
+        return FakeProcess(stderr=b"codex exploded", returncode=2)
+
+    monkeypatch.setattr(p, "_start_process", fake_start)
+
+    with pytest.raises(RuntimeError, match="codex exploded"):
+        _ = [text async for text in p._run_codex(p.build_command("hello"), "/tmp")]
+
+
+@pytest.mark.asyncio
+async def test_stderr_with_empty_success_output_becomes_visible_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    p = provider(workspace="/tmp")
+
+    async def fake_start(command: list[str], cwd: str) -> FakeProcess:
+        return FakeProcess(stderr=b"codex wrote only stderr", returncode=0)
+
+    monkeypatch.setattr(p, "_start_process", fake_start)
+
+    with pytest.raises(RuntimeError, match="codex wrote only stderr"):
+        _ = [text async for text in p._run_codex(p.build_command("hello"), "/tmp")]
+
+
+@pytest.mark.asyncio
+async def test_stdout_converts_to_valid_anthropic_sse_text_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    p = provider(workspace="/tmp")
+
+    async def fake_run(command: list[str], cwd: str, prompt: str = ""):
+        yield "hello from codex"
+
+    monkeypatch.setattr(p, "_run_codex", fake_run)
+
+    events = [
+        event async for event in p.stream_response(request(), request_id="req_test")
+    ]
+
+    assert events[0].startswith("event: message_start")
+    assert events[-1].startswith("event: message_stop")
+    text_delta_events = [event for event in events if "content_block_delta" in event]
+    assert text_delta_events
+    payload = text_delta_events[0].split("data: ", 1)[1]
+    data = json.loads(payload)
+    assert data["delta"] == {"type": "text_delta", "text": "hello from codex"}

--- a/tests/providers/test_codex_cli_registry.py
+++ b/tests/providers/test_codex_cli_registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from config.settings import Settings
+from providers.codex_cli import CodexCliProvider
+from providers.registry import create_provider
+
+
+def test_model_codex_cli_default_validates(monkeypatch):
+    monkeypatch.setitem(Settings.model_config, "env_file", ())
+    monkeypatch.setenv("MODEL", "codex_cli/default")
+
+    settings = Settings()
+
+    assert settings.model == "codex_cli/default"
+    assert settings.provider_type == "codex_cli"
+    assert settings.model_name == "default"
+
+
+def test_registry_builds_codex_cli_without_api_key(monkeypatch):
+    monkeypatch.setitem(Settings.model_config, "env_file", ())
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("MODEL", "codex_cli/default")
+    monkeypatch.setenv("CODEX_CLI_BIN", "codex-test")
+    monkeypatch.setenv("CODEX_WORKSPACE", "/tmp")
+    monkeypatch.setenv("CODEX_TIMEOUT", "12.5")
+
+    settings = Settings()
+    provider = create_provider("codex_cli", settings)
+
+    assert isinstance(provider, CodexCliProvider)
+    assert provider.codex_bin == "codex-test"
+    assert provider.workspace == "/tmp"
+    assert provider.timeout == 12.5

--- a/tests/providers/test_registry.py
+++ b/tests/providers/test_registry.py
@@ -6,6 +6,7 @@ import pytest
 
 from config.nim import NimSettings
 from config.provider_ids import SUPPORTED_PROVIDER_IDS
+from providers.codex_cli import CodexCliProvider
 from providers.deepseek import DeepSeekProvider
 from providers.exceptions import UnknownProviderTypeError
 from providers.llamacpp import LlamaCppProvider
@@ -28,6 +29,10 @@ def _make_settings(**overrides):
     mock.deepseek_api_key = "test_deepseek_key"
     mock.lm_studio_base_url = "http://localhost:1234/v1"
     mock.llamacpp_base_url = "http://localhost:8080/v1"
+    mock.codex_cli_bin = "codex"
+    mock.codex_workspace = ""
+    mock.codex_timeout = 300.0
+    mock.codex_model = ""
     mock.nvidia_nim_proxy = ""
     mock.open_router_proxy = ""
     mock.lmstudio_proxy = ""
@@ -65,7 +70,11 @@ def test_descriptors_cover_advertised_provider_ids():
     assert set(PROVIDER_DESCRIPTORS) == set(SUPPORTED_PROVIDER_IDS)
     for descriptor in PROVIDER_DESCRIPTORS.values():
         assert descriptor.provider_id
-        assert descriptor.transport_type in {"openai_chat", "anthropic_messages"}
+        assert descriptor.transport_type in {
+            "openai_chat",
+            "anthropic_messages",
+            "local_cli",
+        }
         assert descriptor.capabilities
 
 
@@ -83,6 +92,7 @@ def test_create_provider_instantiates_each_builtin():
         "deepseek": DeepSeekProvider,
         "lmstudio": LMStudioProvider,
         "llamacpp": LlamaCppProvider,
+        "codex_cli": CodexCliProvider,
     }
 
     with (


### PR DESCRIPTION
Adds a local codex_cli provider that routes Claude Code proxy requests through the authenticated local Codex CLI without requiring OPENAI_API_KEY.

Validation:
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

Known limitations:
- Claude tool-use blocks are not bridged
- structured tool calls are not bridged
- image inputs are not supported
- streaming is limited by Codex CLI JSON output behavior