### PR TITLE
fix: enhance chat_template handling in request cloning

### DIFF
--- a/providers/nvidia_nim/request.py
+++ b/providers/nvidia_nim/request.py
@@ -47,13 +47,25 @@ def clone_body_without_reasoning_budget(body: dict[str, Any]) -> dict[str, Any] 
 
 
 def clone_body_without_chat_template(body: dict[str, Any]) -> dict[str, Any] | None:
-    """Clone a request body and strip only chat_template."""
+    """Clone a request body and strip chat_template-related extra_body fields.
+
+    NIM may reject Mistral models when *any* of these are present. With
+    ``ENABLE_THINKING=true`` we often send only ``chat_template_kwargs`` (no
+    ``chat_template`` key from NimSettings); a 400 still mentions chat_template
+    and must be retried after removing kwargs too.
+    """
     cloned_body = deepcopy(body)
     extra_body = cloned_body.get("extra_body")
     if not isinstance(extra_body, dict):
         return None
 
-    if extra_body.pop("chat_template", None) is None:
+    removed = False
+    if extra_body.pop("chat_template", None) is not None:
+        removed = True
+    if extra_body.pop("chat_template_kwargs", None) is not None:
+        removed = True
+
+    if not removed:
         return None
 
     if not extra_body:

--- a/tests/providers/test_nvidia_nim.py
+++ b/tests/providers/test_nvidia_nim.py
@@ -324,11 +324,7 @@ async def test_stream_response_retries_without_chat_template(provider_config):
     assert "reasoning_budget" not in first_extra
 
     assert "chat_template" not in second_extra
-    assert second_extra["chat_template_kwargs"] == {
-        "thinking": True,
-        "enable_thinking": True,
-        "reasoning_budget": 100,
-    }
+    assert "chat_template_kwargs" not in second_extra
     assert "reasoning_budget" not in second_extra
 
     event_text = "".join(events)

--- a/tests/providers/test_nvidia_nim_request.py
+++ b/tests/providers/test_nvidia_nim_request.py
@@ -127,13 +127,23 @@ class TestBuildRequestBody:
 
         assert cloned is not None
         assert "chat_template" not in cloned["extra_body"]
-        assert cloned["extra_body"]["chat_template_kwargs"] == {
-            "thinking": True,
-            "enable_thinking": True,
-            "reasoning_budget": 100,
-        }
+        assert "chat_template_kwargs" not in cloned["extra_body"]
         assert cloned["extra_body"]["ignore_eos"] is False
         assert body["extra_body"]["chat_template"] == "custom_template"
+
+    def test_clone_body_without_chat_template_strips_kwargs_only(self):
+        body = {
+            "model": "test",
+            "extra_body": {
+                "chat_template_kwargs": {
+                    "thinking": True,
+                    "enable_thinking": True,
+                },
+            },
+        }
+        cloned = clone_body_without_chat_template(body)
+        assert cloned is not None
+        assert "extra_body" not in cloned
 
     def test_no_chat_template_kwargs_when_thinking_disabled(self):
         req = MagicMock()


### PR DESCRIPTION
Update the `clone_body_without_chat_template` function to strip both `chat_template` and `chat_template_kwargs` from the request body. This change addresses issues with NIM rejecting Mistral models when these fields are present. Additionally, add tests to ensure proper functionality and validate that the `chat_template_kwargs` are removed as expected.