### PR TITLE
docs: fix quick-start uv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,19 @@ A lightweight proxy that routes Claude Code's Anthropic API calls to **NVIDIA NI
 2. Install [Claude Code](https://github.com/anthropics/claude-code)
 
 ### Install `uv`
+
 ```bash
-# Install uv (required to run the project)
-pip install uv
+# Recommended installer (works on macOS/Linux without relying on system pip)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Keep uv current if it is already installed
+uv self update
+
+# This project requires Python 3.14
+uv python install 3.14
 ```
-If uv is already installed, run uv self update to get the latest version.
+
+`pip install uv` can fail on Homebrew-managed Python with `externally-managed-environment` (PEP 668), so prefer the official installer above.
 
 ### Clone & Configure
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ uv self update
 uv python install 3.14
 ```
 
+PowerShell (Windows):
+
+```powershell
+# Recommended installer (avoids relying on system pip)
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+# Keep uv current if it is already installed
+uv self update
+
+# This project requires Python 3.14
+uv python install 3.14
+```
+
 `pip install uv` can fail on Homebrew-managed Python with `externally-managed-environment` (PEP 668), so prefer the official installer above.
 
 ### Clone & Configure


### PR DESCRIPTION
## Summary
The README quick-start path currently tells users to install `uv` with `pip install uv`.

## What I validated
I tried the smallest documented setup path locally and hit a real failure immediately:
- `python3.14 -m pip install uv`
- Result: `externally-managed-environment` (PEP 668) on Homebrew-managed Python

I also checked `pyproject.toml`, which requires Python `>=3.14`.

## Docs fix
- Replaced the `pip install uv` guidance with the official `uv` installer
- Added `uv self update`
- Added `uv python install 3.14`
- Noted why `pip install uv` is unreliable on this kind of macOS/Homebrew setup

## Scope
Docs only: `README.md`