### PR TITLE
feat: add toggle to disable provider throttling

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,7 @@
 """Centralized configuration using Pydantic Settings."""
 
+from __future__ import annotations
+
 import os
 from collections.abc import Mapping
 from functools import lru_cache
@@ -170,6 +172,9 @@ class Settings(BaseSettings):
     )
     enable_haiku_thinking: bool | None = Field(
         default=None, validation_alias="ENABLE_HAIKU_THINKING"
+    )
+    enable_provider_throttling: bool = Field(
+        default=True, validation_alias="ENABLE_PROVIDER_THROTTLING"
     )
 
     # ==================== HTTP Client Timeouts ====================

--- a/docs/throttling.md
+++ b/docs/throttling.md
@@ -1,0 +1,23 @@
+# Provider Throttling
+
+The proxy includes internal rate-limiting and concurrency-capping logic to prevent hitting upstream rate limits and to manage load efficiently.
+
+## Disabling Throttling
+
+In some cases (e.g., when upstream limits are extremely high or handled elsewhere), you may want to disable all internal throttling.
+
+### Environment Variable
+
+Set `ENABLE_PROVIDER_THROTTLING` to `False` in your `.env` file or environment:
+
+```env
+ENABLE_PROVIDER_THROTTLING=False
+```
+
+When set to `False`:
+- `GlobalRateLimiter` will not block requests.
+- Concurrency limits will not be enforced.
+- Automatic retries on 429 errors will be bypassed (requests will fail fast if the upstream returns 429).
+- Reactive throttling (slowing down after errors) will be disabled.
+
+By default, throttling is enabled (`True`).

--- a/providers/anthropic_messages.py
+++ b/providers/anthropic_messages.py
@@ -52,6 +52,7 @@ class AnthropicMessagesTransport(BaseProvider):
             rate_limit=config.rate_limit,
             rate_window=config.rate_window,
             max_concurrency=config.max_concurrency,
+            enabled=config.enable_throttling,
         )
         self._client = httpx.AsyncClient(
             base_url=self._base_url,

--- a/providers/base.py
+++ b/providers/base.py
@@ -25,6 +25,7 @@ class ProviderConfig(BaseModel):
     http_write_timeout: float = 10.0
     http_connect_timeout: float = HTTP_CONNECT_TIMEOUT_DEFAULT
     enable_thinking: bool = True
+    enable_throttling: bool = True
     proxy: str = ""
     log_raw_sse_events: bool = False
     log_api_error_tracebacks: bool = False

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -75,6 +75,7 @@ class OpenAIChatTransport(BaseProvider):
             rate_limit=config.rate_limit,
             rate_window=config.rate_window,
             max_concurrency=config.max_concurrency,
+            enabled=config.enable_throttling,
         )
         http_client = None
         if config.proxy:

--- a/providers/rate_limit.py
+++ b/providers/rate_limit.py
@@ -38,6 +38,7 @@ class GlobalRateLimiter:
         rate_limit: int = 40,
         rate_window: float = 60.0,
         max_concurrency: int = 5,
+        enabled: bool = True,
     ):
         # Prevent re-initialization on singleton reuse
         if hasattr(self, "_initialized"):
@@ -53,6 +54,7 @@ class GlobalRateLimiter:
         self._rate_limit = rate_limit
         self._rate_window = float(rate_window)
         self._max_concurrency = max_concurrency
+        self._enabled = enabled
         self._proactive_limiter = StrictSlidingWindowLimiter(
             self._rate_limit, self._rate_window
         )
@@ -61,7 +63,8 @@ class GlobalRateLimiter:
         self._initialized = True
 
         logger.info(
-            f"GlobalRateLimiter (Provider) initialized ({rate_limit} req / {rate_window}s, max_concurrency={max_concurrency})"
+            f"GlobalRateLimiter (Provider) initialized ({rate_limit} req / {rate_window}s, "
+            f"max_concurrency={max_concurrency}, enabled={enabled})"
         )
 
     @classmethod
@@ -70,6 +73,7 @@ class GlobalRateLimiter:
         rate_limit: int | None = None,
         rate_window: float | None = None,
         max_concurrency: int = 5,
+        enabled: bool = True,
     ) -> GlobalRateLimiter:
         """Get or create the singleton instance.
 
@@ -77,12 +81,14 @@ class GlobalRateLimiter:
             rate_limit: Requests per window (only used on first creation)
             rate_window: Window in seconds (only used on first creation)
             max_concurrency: Max simultaneous open streams (only used on first creation)
+            enabled: Whether the limiter is active (only used on first creation)
         """
         if cls._instance is None:
             cls._instance = cls(
                 rate_limit=rate_limit or 40,
                 rate_window=rate_window or 60.0,
                 max_concurrency=max_concurrency,
+                enabled=enabled,
             )
         return cls._instance
 
@@ -94,6 +100,7 @@ class GlobalRateLimiter:
         rate_limit: int | None = None,
         rate_window: float | None = None,
         max_concurrency: int = 5,
+        enabled: bool = True,
     ) -> GlobalRateLimiter:
         """Get or create a provider-scoped limiter instance."""
         if not scope:
@@ -102,18 +109,20 @@ class GlobalRateLimiter:
         desired_rate_window = float(rate_window or 60.0)
         existing = cls._scoped_instances.get(scope)
         if existing and existing.matches_config(
-            desired_rate_limit, desired_rate_window, max_concurrency
+            desired_rate_limit, desired_rate_window, max_concurrency, enabled
         ):
             return existing
         if existing:
             logger.info(
                 "Rebuilding provider rate limiter for updated scope '{}'", scope
             )
-        cls._scoped_instances[scope] = cls(
-            rate_limit=desired_rate_limit,
-            rate_window=desired_rate_window,
-            max_concurrency=max_concurrency,
-        )
+        if scope not in cls._scoped_instances or existing:
+            cls._scoped_instances[scope] = cls(
+                rate_limit=desired_rate_limit,
+                rate_window=desired_rate_window,
+                max_concurrency=max_concurrency,
+                enabled=enabled,
+            )
         return cls._scoped_instances[scope]
 
     @classmethod
@@ -129,6 +138,9 @@ class GlobalRateLimiter:
         Returns:
             True if was reactively blocked and waited, False otherwise.
         """
+        if not self._enabled:
+            return False
+
         # 1. Reactive check: Wait if someone hit a 429
         waited_reactively = False
         now = time.monotonic()
@@ -168,13 +180,14 @@ class GlobalRateLimiter:
         return time.monotonic() < self._blocked_until
 
     def matches_config(
-        self, rate_limit: int, rate_window: float, max_concurrency: int
+        self, rate_limit: int, rate_window: float, max_concurrency: int, enabled: bool = True
     ) -> bool:
         """Return whether this limiter matches the requested runtime config."""
         return (
             self._rate_limit == rate_limit
             and self._rate_window == float(rate_window)
             and self._max_concurrency == max_concurrency
+            and self._enabled == enabled
         )
 
     def remaining_wait(self) -> float:
@@ -187,6 +200,10 @@ class GlobalRateLimiter:
 
         Blocks until a slot is available (controlled by max_concurrency).
         """
+        if not self._enabled:
+            yield
+            return
+
         await self._concurrency_sem.acquire()
         try:
             yield
@@ -221,6 +238,9 @@ class GlobalRateLimiter:
         Raises:
             The last exception if all retries are exhausted.
         """
+        if not self._enabled:
+            return await fn(*args, **kwargs)
+
         last_exc: Exception | None = None
 
         for attempt in range(1 + max_retries):

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -119,6 +119,7 @@ def build_provider_config(
         http_write_timeout=settings.http_write_timeout,
         http_connect_timeout=settings.http_connect_timeout,
         enable_thinking=settings.enable_model_thinking,
+        enable_throttling=settings.enable_provider_throttling,
         proxy=proxy,
         log_raw_sse_events=settings.log_raw_sse_events,
         log_api_error_tracebacks=settings.log_api_error_tracebacks,

--- a/tests/providers/test_rate_limit_toggle.py
+++ b/tests/providers/test_rate_limit_toggle.py
@@ -1,0 +1,65 @@
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import openai
+import pytest
+
+from providers.rate_limit import GlobalRateLimiter
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_disabled_bypasses_wait():
+    """Verify that when disabled, wait_if_blocked returns immediately even if 'blocked'."""
+    limiter = GlobalRateLimiter(rate_limit=1, rate_window=60, enabled=False)
+    limiter.set_blocked(30)  # Block for 30s
+    
+    start = time.monotonic()
+    waited = await limiter.wait_if_blocked()
+    end = time.monotonic()
+    
+    assert not waited
+    assert end - start < 0.1  # Should be near-instant
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_disabled_bypasses_concurrency():
+    """Verify that when disabled, concurrency_slot does not block."""
+    # Limiter with max_concurrency=1
+    limiter = GlobalRateLimiter(max_concurrency=1, enabled=False)
+    
+    # Acquire two slots simultaneously
+    async with limiter.concurrency_slot():
+        async with limiter.concurrency_slot():
+            # Should reach here without blocking
+            pass
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_disabled_bypasses_retry():
+    """Verify that when disabled, execute_with_retry does not retry on 429."""
+    limiter = GlobalRateLimiter(enabled=False)
+    
+    mock_fn = AsyncMock(side_effect=openai.RateLimitError("Rate limit exceeded", response=AsyncMock(), body={}))
+    
+    with pytest.raises(openai.RateLimitError):
+        await limiter.execute_with_retry(mock_fn)
+    
+    # Should only be called once
+    assert mock_fn.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_enabled_blocks():
+    """Verify that when enabled (default), it still blocks."""
+    limiter = GlobalRateLimiter(rate_limit=1, rate_window=0.1, enabled=True)
+    
+    # Use first slot
+    await limiter.wait_if_blocked()
+    
+    start = time.monotonic()
+    # This should wait for the window to reset
+    await limiter.wait_if_blocked()
+    end = time.monotonic()
+    
+    assert end - start >= 0.1


### PR DESCRIPTION
## Description
This PR introduces a new configuration option to completely bypass the internal provider-level throttling logic (proactive, reactive, and concurrency capping).

While the proxy's internal rate limiting is beneficial for most users, those with high-tier API limits or local provider setups (like LM Studio or Ollama) may prefer to disable these checks to reduce latency and allow the upstream provider to handle request volume entirely.

### Key Changes
- **Configuration**: Added `ENABLE_PROVIDER_THROTTLING` environment variable (defaults to `True`).
- **Rate Limiter**: Updated `GlobalRateLimiter` to respect the `enabled` flag. When disabled:
    - `wait_if_blocked()` returns immediately.
    - `concurrency_slot()` yields without acquiring a semaphore.
    - `execute_with_retry()` executes the request directly without internal retries on 429s (fail-fast behavior).
- **Documentation**: Added `docs/throttling.md` explaining how to use the toggle.
- **Verification**: Added unit tests in `tests/providers/test_rate_limit_toggle.py` to ensure the bypass logic works as expected.

### How to use
Set the following in your `.env` file:
```env
ENABLE_PROVIDER_THROTTLING=False
```

### Testing
- Created new unit tests verifying that all limiter modes (wait, concurrency, and retry) are bypassed when the toggle is off.
- Verified that default behavior remains unchanged (throttling active by default).
- Confirmed that settings are correctly propagated through the provider registry to individual transport instances.