### PR TITLE
Run CI across Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,15 @@ concurrency:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    name: CI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -24,6 +29,7 @@ jobs:
           fetch-depth: 1
 
       - name: "Fail on type: ignore (no suppressions allowed)"
+        shell: bash
         run: |
           if grep -rE '# type: ignore|# ty: ignore' --include='*.py' . --exclude-dir=.venv --exclude-dir=.git; then
             echo "::error::type: ignore / ty: ignore comments are not allowed. Fix the underlying type errors instead."
@@ -37,6 +43,9 @@ jobs:
           version: "0.10.4"
           enable-cache: true
           cache-python: true
+
+      - name: Install Python 3.14
+        run: uv python install 3.14
 
       - name: Format check
         run: uv run ruff format --check


### PR DESCRIPTION
## Summary

Expands the existing GitHub Actions CI workflow to run across:

- `ubuntu-latest`
- `macos-latest`
- `windows-latest`

## Why

This project documents usage across multiple developer environments, including Windows-specific and shell-specific setup paths, but the current CI workflow validates only `ubuntu-latest`.

Running the same checks across Linux, macOS, and Windows improves portability coverage and helps catch OS-specific issues earlier, especially for a developer-facing tool that is intended to run in varied local environments.

## What this changes

- Adds a GitHub Actions matrix for `ubuntu-latest`, `macos-latest`, and `windows-latest`
- Keeps the existing CI checks intact:
  - format check
  - lint
  - type check
  - test suite
- Uses `bash` specifically for the existing `grep`-based suppression check so it behaves consistently across runners
- Explicitly installs Python 3.14 in CI to match the repository’s documented and configured runtime target

## Risk

Low to moderate. This change does not alter application runtime behavior, but it may expose existing cross-platform issues that were previously hidden by Linux-only CI.

## Validation

- Preserves the existing SHA-pinned action usage
- Keeps the workflow scoped to CI only
- Matches the repository’s documented Python 3.14 requirement
