### PR TITLE
Add launchd service wrapper for the server (macOS)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,29 @@
+# Server as a launchd service (macOS)
+
+Run the free-claude-code server as a managed background service with simple start/stop/restart.
+
+## Install
+
+```bash
+./scripts/install-service.sh   # writes ~/Library/LaunchAgents/com.fcc.server.plist
+./scripts/fccd start
+```
+
+## Control
+
+```bash
+./scripts/fccd start      # load + start
+./scripts/fccd stop       # stop + unload
+./scripts/fccd restart    # kickstart in place
+./scripts/fccd status     # state, pid, last exit code
+./scripts/fccd logs       # tail server.log
+./scripts/fccd enable     # auto-start on login
+./scripts/fccd disable    # remove auto-start
+```
+
+The service runs `uv run uvicorn server:app` on `0.0.0.0:8082`, restarts on crash
+(`KeepAlive`/`SuccessfulExit=false`), and writes stdout+stderr to `server.log`
+in the repo root.
+
+To change host/port, edit `scripts/com.fcc.server.plist.template` and re-run
+`install-service.sh`, then `fccd restart`.

--- a/scripts/com.fcc.server.plist.template
+++ b/scripts/com.fcc.server.plist.template
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.fcc.server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__UV__</string>
+        <string>run</string>
+        <string>uvicorn</string>
+        <string>server:app</string>
+        <string>--host</string>
+        <string>0.0.0.0</string>
+        <string>--port</string>
+        <string>8082</string>
+        <string>--timeout-graceful-shutdown</string>
+        <string>5</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__REPO__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__PATH__</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__REPO__/server.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__REPO__/server.log</string>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/scripts/fccd
+++ b/scripts/fccd
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# fccd — control the free-claude-code server (launchd-managed)
+set -euo pipefail
+
+LABEL="com.fcc.server"
+PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+LOG="/Users/ehanlonmiller/git/free-claude-code/server.log"
+
+usage() {
+    cat <<EOF
+Usage: fccd <command>
+
+Commands:
+  start      Load and start the server
+  stop       Stop and unload the server
+  restart    Stop then start
+  status     Show launchd status (PID, last exit code)
+  logs       Tail server.log
+  enable     Auto-start on login (RunAtLoad=true via bootstrap)
+  disable    Remove auto-start (bootout)
+EOF
+}
+
+case "${1:-}" in
+    start)
+        launchctl load -w "$PLIST" 2>/dev/null || true
+        launchctl kickstart -k "gui/$(id -u)/$LABEL"
+        echo "started $LABEL"
+        ;;
+    stop)
+        launchctl unload "$PLIST" 2>/dev/null || true
+        echo "stopped $LABEL"
+        ;;
+    restart)
+        launchctl kickstart -k "gui/$(id -u)/$LABEL" 2>/dev/null || {
+            launchctl load -w "$PLIST"
+            launchctl kickstart -k "gui/$(id -u)/$LABEL"
+        }
+        echo "restarted $LABEL"
+        ;;
+    status)
+        launchctl print "gui/$(id -u)/$LABEL" 2>/dev/null | grep -E "state|pid|last exit code" || echo "not loaded"
+        ;;
+    logs)
+        tail -f "$LOG"
+        ;;
+    enable)
+        launchctl bootstrap "gui/$(id -u)" "$PLIST" 2>/dev/null || true
+        launchctl enable "gui/$(id -u)/$LABEL"
+        echo "enabled $LABEL (auto-start on login)"
+        ;;
+    disable)
+        launchctl bootout "gui/$(id -u)/$LABEL" 2>/dev/null || true
+        echo "disabled $LABEL"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/scripts/install-service.sh
+++ b/scripts/install-service.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# install-service.sh — install the launchd plist for the fcc server.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+TEMPLATE="$REPO/scripts/com.fcc.server.plist.template"
+DEST="$HOME/Library/LaunchAgents/com.fcc.server.plist"
+
+UV="$(command -v uv || true)"
+if [[ -z "$UV" ]]; then
+    echo "error: uv not found on PATH. Install from https://astral.sh/uv" >&2
+    exit 1
+fi
+
+mkdir -p "$HOME/Library/LaunchAgents"
+
+sed \
+    -e "s|__UV__|$UV|g" \
+    -e "s|__REPO__|$REPO|g" \
+    -e "s|__PATH__|$PATH|g" \
+    "$TEMPLATE" > "$DEST"
+
+echo "installed $DEST"
+echo "next: $REPO/scripts/fccd start"


### PR DESCRIPTION
## Summary
- Adds `scripts/fccd`, a small wrapper providing `start | stop | restart | status | logs | enable | disable` for running the server as a managed background service on macOS.
- Adds `scripts/com.fcc.server.plist.template` and `scripts/install-service.sh` to install a per-user launchd agent that runs `uv run uvicorn server:app` on `0.0.0.0:8082`, restarts on non-zero exit (`KeepAlive`/`SuccessfulExit=false`), and logs to `server.log`.
- Adds `scripts/README.md` documenting install + control commands.

## Why
Makes it easy to keep the server running in the background and stop/start/restart it without remembering the full uvicorn invocation, and gives crash-restart for free.

## Notes for reviewers
- macOS-only (launchd). No changes to server code.
- Auto-start on login is opt-in via `fccd enable` (the plist sets `RunAtLoad=false` by default).
- The install script substitutes the user's `uv` path, repo path, and `$PATH` into the template at install time so it works regardless of where the repo is cloned.

## Test plan
- [x] `./scripts/install-service.sh` writes `~/Library/LaunchAgents/com.fcc.server.plist`
- [x] `./scripts/fccd start` brings the server up; `curl http://127.0.0.1:8082/` returns 200
- [x] `./scripts/fccd restart` rotates the process and the server stays reachable
- [x] `./scripts/fccd stop` unloads the agent