### PR TITLE
fix: use Python 3 syntax for catching multiple exceptions in tokens.py

### DIFF
--- a/core/anthropic/tokens.py
+++ b/core/anthropic/tokens.py
@@ -96,7 +96,7 @@ def get_token_count(
                     )
                     try:
                         total_tokens += len(ENCODER.encode(json.dumps(block)))
-                    except TypeError, ValueError:
+                    except (TypeError, ValueError):
                         total_tokens += len(ENCODER.encode(str(block)))
 
     if tools:


### PR DESCRIPTION
## Summary

Fixes a Python 2 syntax bug in `core/anthropic/tokens.py` that causes a `SyntaxError` at import time.

## Problem

Line 99 uses the Python 2-only bare-comma exception syntax:

```python
except TypeError, ValueError:
```

In Python 3 this is a `SyntaxError`, causing the entire `core.anthropic.tokens` module to fail on import. Since token counting is used for every API request, this completely breaks the proxy for anyone on a version where this code path is exercised.

## Fix

Wrap the exception types in parentheses (the Python 3 correct form):

```python
except (TypeError, ValueError):
```

## Testing

Before: `python3 -c "from core.anthropic.tokens import get_token_count"` → `SyntaxError`  
After: imports cleanly.

Closes #211

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>