### PR TITLE
Added context usage tracking and warning logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,3 +134,5 @@ LOG_RAW_MESSAGING_CONTENT=false
 LOG_RAW_CLI_DIAGNOSTICS=false
 # When true, log full exception and CLI error message strings in messaging (may leak user content).
 LOG_MESSAGING_ERROR_DETAILS=false
+# Warn when cumulative input context exceeds this ratio of known model context window.
+CONTEXT_WARN_THRESHOLD=0.75

--- a/api/context_usage.py
+++ b/api/context_usage.py
@@ -1,0 +1,138 @@
+"""Session-level context usage tracking from Anthropic-style usage fields."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from threading import Lock
+
+from loguru import logger
+
+
+@dataclass(frozen=True, slots=True)
+class ContextUsageSnapshot:
+    """Computed context usage values for one model after a request."""
+
+    label: str
+    limit_tokens: int
+    cumulative_input_tokens: int
+    percent_used: int
+    ratio_used: float
+    bar: str
+
+
+_KNOWN_MODEL_LIMITS: tuple[tuple[tuple[str, ...], str, int], ...] = (
+    (("glm-5.1", "glm5.1"), "GLM-5.1", 200_000),
+    (("kimi-k2.5", "k2.5"), "K2.5", 256_000),
+    (("glm4.7", "glm-4.7"), "GLM-4.7", 128_000),
+    (("glm5", "glm-5"), "GLM-5", 128_000),
+)
+
+
+def _find_model_limit(model_name: str) -> tuple[str, int] | None:
+    lowered = model_name.strip().lower()
+    for aliases, display_label, limit_tokens in _KNOWN_MODEL_LIMITS:
+        if any(alias in lowered for alias in aliases):
+            return display_label, limit_tokens
+    return None
+
+
+def _format_tokens_k(tokens: int) -> str:
+    if tokens < 1_000:
+        return str(tokens)
+    return f"{round(tokens / 1_000):.0f}K"
+
+
+def _build_context_bar(ratio_used: float, width: int = 10) -> str:
+    clamped = max(0.0, min(ratio_used, 1.0))
+    filled = max(0, min(width, round(clamped * width)))
+    return "█" * filled + "░" * (width - filled)
+
+
+def extract_usage_input_tokens_from_sse_event(event: str) -> int | None:
+    """Extract usage.input_tokens from one SSE event string when present."""
+    for raw_line in event.splitlines():
+        line = raw_line.strip()
+        if not line.startswith("data: "):
+            continue
+        payload = line.removeprefix("data: ").strip()
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+
+        direct_usage = parsed.get("usage")
+        if isinstance(direct_usage, dict):
+            value = direct_usage.get("input_tokens")
+            if isinstance(value, int):
+                return value
+
+        message = parsed.get("message")
+        if isinstance(message, dict):
+            nested_usage = message.get("usage")
+            if isinstance(nested_usage, dict):
+                value = nested_usage.get("input_tokens")
+                if isinstance(value, int):
+                    return value
+    return None
+
+
+class SessionContextUsageTracker:
+    """Track cumulative per-model input token usage during proxy process lifetime."""
+
+    def __init__(self, warn_threshold: float):
+        self._warn_threshold = warn_threshold
+        self._cumulative_input_by_model: dict[str, int] = {}
+        self._lock = Lock()
+
+    def record_usage(
+        self, *, model_name: str, input_tokens: int
+    ) -> ContextUsageSnapshot | None:
+        """Record one request's input tokens and emit context logs when model limit is known."""
+        if input_tokens < 0:
+            return None
+
+        model_limit = _find_model_limit(model_name)
+        if model_limit is None:
+            return None
+        label, limit_tokens = model_limit
+
+        with self._lock:
+            prior = self._cumulative_input_by_model.get(label, 0)
+            updated = prior + input_tokens
+            self._cumulative_input_by_model[label] = updated
+
+        ratio_used = updated / limit_tokens if limit_tokens > 0 else 0.0
+        percent_used = round(ratio_used * 100)
+        bar = _build_context_bar(ratio_used)
+
+        logger.info(
+            "[Context: {} {}% | {}/{} tokens | {}]",
+            bar,
+            percent_used,
+            _format_tokens_k(updated),
+            _format_tokens_k(limit_tokens),
+            label,
+        )
+
+        prior_ratio = prior / limit_tokens if limit_tokens > 0 else 0.0
+        crossed_threshold = prior_ratio < self._warn_threshold <= ratio_used
+        if crossed_threshold:
+            logger.warning(
+                "Context usage at {:.1f}% for {} ({} / {} tokens). Run /compact soon.",
+                ratio_used * 100.0,
+                label,
+                updated,
+                limit_tokens,
+            )
+
+        return ContextUsageSnapshot(
+            label=label,
+            limit_tokens=limit_tokens,
+            cumulative_input_tokens=updated,
+            percent_used=percent_used,
+            ratio_used=ratio_used,
+            bar=bar,
+        )

--- a/api/services.py
+++ b/api/services.py
@@ -17,9 +17,13 @@ from core.anthropic.sse import ANTHROPIC_SSE_RESPONSE_HEADERS
 from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
 
+from .context_usage import (
+    SessionContextUsageTracker,
+    extract_usage_input_tokens_from_sse_event,
+)
 from .model_router import ModelRouter
 from .models.anthropic import MessagesRequest, TokenCountRequest
-from .models.responses import TokenCountResponse
+from .models.responses import MessagesResponse, TokenCountResponse
 from .optimization_handlers import try_optimizations
 from .web_tools.egress import WebFetchEgressPolicy
 from .web_tools.request import (
@@ -34,6 +38,7 @@ ProviderGetter = Callable[[str], BaseProvider]
 
 # Providers that use ``/chat/completions`` + Anthropic-to-OpenAI conversion (not native Messages).
 _OPENAI_CHAT_UPSTREAM_IDS = frozenset({"nvidia_nim"})
+_CONTEXT_USAGE_TRACKERS_BY_THRESHOLD: dict[float, SessionContextUsageTracker] = {}
 
 
 def anthropic_sse_streaming_response(
@@ -92,11 +97,43 @@ class ClaudeProxyService:
         provider_getter: ProviderGetter,
         model_router: ModelRouter | None = None,
         token_counter: TokenCounter = get_token_count,
+        context_usage_tracker: SessionContextUsageTracker | None = None,
     ):
         self._settings = settings
         self._provider_getter = provider_getter
         self._model_router = model_router or ModelRouter(settings)
         self._token_counter = token_counter
+        self._context_usage_tracker = (
+            context_usage_tracker
+            if context_usage_tracker is not None
+            else _CONTEXT_USAGE_TRACKERS_BY_THRESHOLD.setdefault(
+                settings.context_warn_threshold,
+                SessionContextUsageTracker(
+                    warn_threshold=settings.context_warn_threshold
+                ),
+            )
+        )
+
+    async def _stream_with_context_usage_tracking(
+        self, body: AsyncIterator[str], *, model_name: str
+    ) -> AsyncIterator[str]:
+        tracked = False
+        async for event in body:
+            if not tracked:
+                usage_input_tokens = extract_usage_input_tokens_from_sse_event(event)
+                if usage_input_tokens is not None:
+                    self._context_usage_tracker.record_usage(
+                        model_name=model_name,
+                        input_tokens=usage_input_tokens,
+                    )
+                    tracked = True
+            yield event
+
+    def _track_optimized_response_usage(self, response: MessagesResponse) -> None:
+        self._context_usage_tracker.record_usage(
+            model_name=response.model,
+            input_tokens=response.usage.input_tokens,
+        )
 
     def create_message(self, request_data: MessagesRequest) -> object:
         """Create a message response or streaming response."""
@@ -124,16 +161,20 @@ class ClaudeProxyService:
                     allowed_schemes=self._settings.web_fetch_allowed_scheme_set(),
                 )
                 return anthropic_sse_streaming_response(
-                    stream_web_server_tool_response(
-                        routed.request,
-                        input_tokens=input_tokens,
-                        web_fetch_egress=egress,
-                        verbose_client_errors=self._settings.log_api_error_tracebacks,
-                    ),
+                    self._stream_with_context_usage_tracking(
+                        stream_web_server_tool_response(
+                            routed.request,
+                            input_tokens=input_tokens,
+                            web_fetch_egress=egress,
+                            verbose_client_errors=self._settings.log_api_error_tracebacks,
+                        ),
+                        model_name=routed.request.model,
+                    )
                 )
 
             optimized = try_optimizations(routed.request, self._settings)
             if optimized is not None:
+                self._track_optimized_response_usage(optimized)
                 return optimized
             logger.debug("No optimization matched, routing to provider")
 
@@ -159,12 +200,15 @@ class ClaudeProxyService:
                 routed.request.messages, routed.request.system, routed.request.tools
             )
             return anthropic_sse_streaming_response(
-                provider.stream_response(
-                    routed.request,
-                    input_tokens=input_tokens,
-                    request_id=request_id,
-                    thinking_enabled=routed.resolved.thinking_enabled,
-                ),
+                self._stream_with_context_usage_tracking(
+                    provider.stream_response(
+                        routed.request,
+                        input_tokens=input_tokens,
+                        request_id=request_id,
+                        thinking_enabled=routed.resolved.thinking_enabled,
+                    ),
+                    model_name=routed.request.model,
+                )
             )
 
         except ProviderError:

--- a/config/settings.py
+++ b/config/settings.py
@@ -231,6 +231,10 @@ class Settings(BaseSettings):
     log_messaging_error_details: bool = Field(
         default=False, validation_alias="LOG_MESSAGING_ERROR_DETAILS"
     )
+    # Warn when cumulative context usage for a known model crosses this ratio.
+    context_warn_threshold: float = Field(
+        default=0.75, validation_alias="CONTEXT_WARN_THRESHOLD"
+    )
     debug_platform_edits: bool = Field(
         default=False, validation_alias="DEBUG_PLATFORM_EDITS"
     )
@@ -347,6 +351,13 @@ class Settings(BaseSettings):
     def validate_messaging_rate_window(cls, v: float) -> float:
         if v <= 0:
             raise ValueError("messaging_rate_window must be > 0")
+        return float(v)
+
+    @field_validator("context_warn_threshold")
+    @classmethod
+    def validate_context_warn_threshold(cls, v: float) -> float:
+        if v <= 0 or v > 1:
+            raise ValueError("context_warn_threshold must be in (0, 1]")
         return float(v)
 
     @field_validator("web_fetch_allowed_schemes")

--- a/tests/api/test_context_usage.py
+++ b/tests/api/test_context_usage.py
@@ -1,0 +1,95 @@
+"""Tests for session-level context usage tracking and SSE usage parsing."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.context_usage import (
+    SessionContextUsageTracker,
+    extract_usage_input_tokens_from_sse_event,
+)
+from api.services import ClaudeProxyService
+from config.settings import Settings
+
+
+def test_extract_usage_input_tokens_from_message_start_event() -> None:
+    event = (
+        "event: message_start\n"
+        'data: {"type":"message_start","message":{"usage":{"input_tokens":156000,"output_tokens":1}}}\n\n'
+    )
+
+    assert extract_usage_input_tokens_from_sse_event(event) == 156000
+
+
+def test_extract_usage_input_tokens_from_message_delta_event() -> None:
+    event = (
+        "event: message_delta\n"
+        'data: {"type":"message_delta","usage":{"input_tokens":2000,"output_tokens":100}}\n\n'
+    )
+
+    assert extract_usage_input_tokens_from_sse_event(event) == 2000
+
+
+def test_tracker_logs_context_bar_and_warns_on_threshold_crossing() -> None:
+    tracker = SessionContextUsageTracker(warn_threshold=0.75)
+
+    with (
+        patch("api.context_usage.logger.info") as info_log,
+        patch("api.context_usage.logger.warning") as warn_log,
+    ):
+        tracker.record_usage(model_name="z-ai/glm-5.1", input_tokens=100_000)
+        tracker.record_usage(model_name="z-ai/glm-5.1", input_tokens=60_000)
+
+    assert info_log.call_count == 2
+    context_log_template = str(info_log.call_args_list[-1].args[0])
+    assert context_log_template.startswith("[Context: ")
+    assert "{}%" in context_log_template
+    assert "{}/{} tokens" in context_log_template
+    assert warn_log.call_count == 1
+    assert "Run /compact soon." in str(warn_log.call_args.args[0])
+
+
+def test_tracker_skips_unknown_model_without_logging() -> None:
+    tracker = SessionContextUsageTracker(warn_threshold=0.75)
+    with patch("api.context_usage.logger.info") as info_log:
+        result = tracker.record_usage(
+            model_name="custom/unknown-model", input_tokens=500
+        )
+
+    assert result is None
+    info_log.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_service_stream_tracking_reads_usage_from_sse_event() -> None:
+    settings = Settings()
+    tracker = MagicMock(spec=SessionContextUsageTracker)
+
+    service = ClaudeProxyService(
+        settings,
+        provider_getter=lambda _: MagicMock(),
+        context_usage_tracker=tracker,
+    )
+
+    async def fake_stream() -> AsyncIterator[str]:
+        yield (
+            "event: message_start\n"
+            'data: {"type":"message_start","message":{"usage":{"input_tokens":1234,"output_tokens":1}}}\n\n'
+        )
+        yield 'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+
+    chunks = [
+        chunk
+        async for chunk in service._stream_with_context_usage_tracking(
+            fake_stream(), model_name="z-ai/glm-5.1"
+        )
+    ]
+
+    assert len(chunks) == 2
+    tracker.record_usage.assert_called_once_with(
+        model_name="z-ai/glm-5.1",
+        input_tokens=1234,
+    )

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -40,8 +40,25 @@ class TestSettings:
         assert settings.enable_web_server_tools is False
         assert settings.log_raw_api_payloads is False
         assert settings.log_raw_sse_events is False
+        assert settings.context_warn_threshold == 0.75
         assert settings.debug_platform_edits is False
         assert settings.debug_subagent_stack is False
+
+    def test_context_warn_threshold_from_env(self, monkeypatch):
+        """CONTEXT_WARN_THRESHOLD env var is loaded into settings."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("CONTEXT_WARN_THRESHOLD", "0.8")
+        settings = Settings()
+        assert settings.context_warn_threshold == 0.8
+
+    def test_context_warn_threshold_must_be_in_range(self, monkeypatch):
+        """CONTEXT_WARN_THRESHOLD must be in the open/closed interval (0, 1]."""
+        from config.settings import Settings
+
+        monkeypatch.setenv("CONTEXT_WARN_THRESHOLD", "0")
+        with pytest.raises(ValidationError, match="context_warn_threshold"):
+            Settings()
 
     def test_get_settings_cached(self):
         """Test get_settings returns cached instance."""


### PR DESCRIPTION
Added context usage tracking for long Claude Code proxy sessions.

New features
Tracks total input tokens used during the session.
Shows a context usage bar after every request.

Example:

[Context: ████████░░ 78% | 156K/200K tokens | GLM-5.1]
Warns users when usage gets too high.
Suggests using /compact before reaching the limit.
Added model limits

Supports known limits such as:

GLM-5.1 = 200K
K2.5 = 256K
GLM-4.7 = 128K
GLM-5 = 128K
Config added

New env variable:

CONTEXT_WARN_THRESHOLD

Default:

0.75

Tested

All checks passed successfully - 1152 tests passed