### PR TITLE
Log configured model routing on startup

### DIFF
--- a/api/runtime.py
+++ b/api/runtime.py
@@ -61,6 +61,17 @@ def warn_if_process_auth_token(settings: Settings) -> None:
         )
 
 
+def log_model_configuration(settings: Settings) -> None:
+    """Log the resolved Claude-to-provider model routing on startup."""
+    logger.info(
+        "Configured model routing: default={} opus={} sonnet={} haiku={}",
+        settings.model,
+        settings.model_opus or "<inherit default>",
+        settings.model_sonnet or "<inherit default>",
+        settings.model_haiku or "<inherit default>",
+    )
+
+
 @dataclass(slots=True)
 class AppRuntime:
     """Own optional messaging, CLI, session, and provider runtime resources."""
@@ -84,6 +95,7 @@ class AppRuntime:
         logger.info("Starting Claude Code Proxy...")
         self._provider_registry = ProviderRegistry()
         self.app.state.provider_registry = self._provider_registry
+        log_model_configuration(self.settings)
         warn_if_process_auth_token(self.settings)
         await self._start_messaging_if_configured()
         self._publish_state()

--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -9,6 +9,7 @@ included at top level for easy grep/filter.
 import json
 import logging
 import re
+import sys
 from pathlib import Path
 
 from loguru import logger
@@ -104,6 +105,12 @@ def configure_logging(
         encoding="utf-8",
         mode="a",
         rotation="50 MB",
+    )
+    logger.add(
+        sys.stderr,
+        level="INFO",
+        format="{time:YYYY-MM-DD HH:mm:ss} | {level} | {message}",
+        colorize=False,
     )
 
     # Intercept stdlib logging: route all root logger output to loguru


### PR DESCRIPTION
## Summary

This PR makes the active model routing visible during server startup.

- Logs the resolved default `MODEL` and the optional `MODEL_OPUS`, `MODEL_SONNET`, and `MODEL_HAIKU` overrides when the app starts.
- Adds an INFO-level stderr log sink so startup diagnostics are visible in the terminal when running `free-claude-code` or `uvicorn`, while preserving the existing JSON file log output.

## Motivation

When users update `.env` and restart the proxy, it is currently difficult to confirm which provider/model routing is actually active without running an extra inspection command or checking internal settings. A startup log line makes configuration changes easier to verify and reduces ambiguity when debugging model selection.

Example output:

```text
Configured model routing: default=nvidia_nim/z-ai/glm-5.1 opus=<inherit default> sonnet=<inherit default> haiku=<inherit default>
```

## Validation

- `uv run ruff format --check api/runtime.py config/logging_config.py`
- `uv run ruff check api/runtime.py config/logging_config.py`
- `uv run python -m compileall api/runtime.py config/logging_config.py`
- Started the server on a temporary port and confirmed the model routing line appears in terminal startup logs.

No test files are included in this PR; the change is limited to startup observability.
