### PR TITLE
fix(security): constant-time comparison for ANTHROPIC_AUTH_TOKEN

### DIFF
--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,5 +1,7 @@
 """Dependency injection for FastAPI."""
 
+import secrets
+
 from fastapi import Depends, HTTPException, Request
 from loguru import logger
 from starlette.applications import Starlette
@@ -116,7 +118,11 @@ def require_api_key(
     if token and ":" in token:
         token = token.split(":", 1)[0]
 
-    if token != anthropic_auth_token:
+    # Constant-time comparison to avoid leaking the configured token via
+    # response-time differences on a per-byte mismatch (CWE-208).
+    if not secrets.compare_digest(
+        token.encode("utf-8"), anthropic_auth_token.encode("utf-8")
+    ):
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 


### PR DESCRIPTION
## Security Vulnerability Report

**Type:** Timing-attack on API key validation (CWE-208 / Observable Timing Discrepancy)
**Severity:** medium
**Location:** `api/dependencies.py:119`

### Description

`require_api_key()` validates the client-supplied token against `Settings.anthropic_auth_token` with a plain `!=` comparison:

```python
if token != anthropic_auth_token:
    raise HTTPException(status_code=401, detail="Invalid API key")
```

Python's `==` / `!=` on `str` short-circuits at the first byte that differs, so the time taken to reject a wrong key correlates with how many leading bytes are correct. Combined with the default bind address (`host = "0.0.0.0"`, `config/settings.py:276`), an attacker on the same LAN as the proxy can issue many requests, measure response times, and recover `ANTHROPIC_AUTH_TOKEN` byte-by-byte. Sub-millisecond LAN latency makes this far more practical than the same attack across the public internet.

The token gates `/v1/messages`, `/v1/messages/count_tokens`, `/v1/models`, and `/stop`, so recovering it lets an attacker drive the locally-running Claude Code CLI through the proxy.

### Fix

Switch to `secrets.compare_digest`, which compares all bytes in constant time:

```python
import secrets
...
if not secrets.compare_digest(
    token.encode("utf-8"), anthropic_auth_token.encode("utf-8")
):
    raise HTTPException(status_code=401, detail="Invalid API key")
```

Behavior is unchanged for valid and invalid tokens — only the timing characteristics change. The existing `tests/api/test_auth.py` cases (correct key, wrong key, missing key, Bearer vs X-API-Key) continue to pass.

### Impact

Without this fix, anyone on the same network as the proxy (home Wi-Fi, coworking space, shared dev VM) can recover `ANTHROPIC_AUTH_TOKEN` and gain full access to the proxied Claude Code CLI session.

---
Found by [Aeon](https://github.com/aaronjmars/aeon-aaron) — automated security scanner