### PR TITLE
fix: validate smoke config env inputs

### DIFF
--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -110,7 +110,7 @@ class SmokeConfig:
             interactive=os.getenv("FCC_SMOKE_INTERACTIVE") == "1",
             targets=_parse_targets(os.getenv("FCC_SMOKE_TARGETS")),
             provider_matrix=_parse_csv(os.getenv("FCC_SMOKE_PROVIDER_MATRIX")),
-            timeout_s=float(os.getenv("FCC_SMOKE_TIMEOUT_S", "45")),
+            timeout_s=_parse_timeout_s(os.getenv("FCC_SMOKE_TIMEOUT_S")),
             prompt=os.getenv("FCC_SMOKE_PROMPT", "Reply with exactly: FCC_SMOKE_PONG"),
             claude_bin=os.getenv("FCC_SMOKE_CLAUDE_BIN", "claude"),
             worker_id=os.getenv("PYTEST_XDIST_WORKER", "main"),
@@ -132,7 +132,7 @@ class SmokeConfig:
         for source, model in candidates:
             if not model or model in seen:
                 continue
-            provider = Settings.parse_provider_type(model)
+            provider = _parse_provider_type(model, source)
             if self.provider_matrix and provider not in self.provider_matrix:
                 continue
             if not self.has_provider_configuration(provider):
@@ -201,6 +201,24 @@ def _parse_targets(raw: str | None) -> frozenset[str]:
     if "all" in parsed:
         return ALL_TARGETS
     return frozenset(TARGET_ALIASES.get(target, target) for target in parsed)
+
+
+def _parse_timeout_s(raw: str | None) -> float:
+    if raw is None:
+        return 45.0
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ValueError("FCC_SMOKE_TIMEOUT_S must be a number") from exc
+
+
+def _parse_provider_type(raw_model: str, source: str) -> str:
+    try:
+        return Settings.parse_provider_type(raw_model)
+    except (IndexError, ValueError) as exc:
+        raise ValueError(
+            f"{source} must be a non-empty provider/model reference"
+        ) from exc
 
 
 def _provider_smoke_model(provider: str) -> tuple[str, str]:

--- a/smoke/lib/config.py
+++ b/smoke/lib/config.py
@@ -213,12 +213,18 @@ def _parse_timeout_s(raw: str | None) -> float:
 
 
 def _parse_provider_type(raw_model: str, source: str) -> str:
-    try:
-        return Settings.parse_provider_type(raw_model)
-    except (IndexError, ValueError) as exc:
+    model = raw_model.strip()
+    if not model or "/" not in model:
         raise ValueError(
             f"{source} must be a non-empty provider/model reference"
-        ) from exc
+        )
+
+    provider = Settings.parse_provider_type(model)
+    if provider not in SUPPORTED_PROVIDER_IDS:
+        raise ValueError(
+            f"{source} must use a supported provider prefix, got {provider!r}"
+        )
+    return provider
 
 
 def _provider_smoke_model(provider: str) -> tuple[str, str]:

--- a/tests/contracts/test_smoke_config.py
+++ b/tests/contracts/test_smoke_config.py
@@ -8,6 +8,7 @@ from smoke.lib.config import (
     PROVIDER_SMOKE_DEFAULT_MODELS,
     TARGET_REQUIRED_ENV,
     SmokeConfig,
+    _parse_provider_type,
 )
 
 
@@ -173,3 +174,21 @@ def test_provider_smoke_does_not_include_default_local_urls_when_unmapped(
     config = _smoke_config(settings=_settings(model="nvidia_nim/test"))
 
     assert config.provider_smoke_models() == []
+
+
+def test_parse_provider_type_rejects_missing_separator() -> None:
+    try:
+        _parse_provider_type("foobar", "MODEL")
+    except ValueError as exc:
+        assert "MODEL must be a non-empty provider/model reference" in str(exc)
+    else:
+        raise AssertionError("expected malformed MODEL to fail")
+
+
+def test_parse_provider_type_rejects_unknown_provider_prefix() -> None:
+    try:
+        _parse_provider_type("foobar/model-x", "MODEL")
+    except ValueError as exc:
+        assert "MODEL must use a supported provider prefix" in str(exc)
+    else:
+        raise AssertionError("expected unknown provider prefix to fail")


### PR DESCRIPTION
## Summary
Smoke config loading could surface raw parsing exceptions when `FCC_SMOKE_TIMEOUT_S` or configured `MODEL_*` values were malformed. This change adds narrow validation wrappers so those failures become explicit operator-facing `ValueError`s that name the bad setting.
## Why it matters
A bad smoke env value currently fails with a low-context exception from `float()` or model parsing internals, which makes CI and local triage harder. Naming the offending setting turns the same failure into an actionable configuration error without changing successful paths.
## Testing
Verified by code-path inspection that valid timeout and model values still resolve through the same logic and produce identical results. Malformed timeout or model-reference inputs now fail deterministically with a clear `ValueError` message identifying the bad setting.