### PR TITLE
fix(nim): reject model names without vendor prefix at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ provider_id/model/name
 
 | Provider | Prefix | Transport | Key | Default base URL |
 | --- | --- | --- | --- | --- |
-| <img src="https://cdn.simpleicons.org/nvidia/76B900" alt="" width="18" height="18"> NVIDIA NIM | `nvidia_nim/...` | OpenAI chat translation | `NVIDIA_NIM_API_KEY` | `https://integrate.api.nvidia.com/v1` |
-| <img src="https://cdn.simpleicons.org/openrouter/6C47FF" alt="" width="18" height="18"> OpenRouter | `open_router/...` | Anthropic Messages | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1` |
-| <img src="https://cdn.simpleicons.org/deepseek/4D6BFF" alt="" width="18" height="18"> DeepSeek | `deepseek/...` | Anthropic Messages | `DEEPSEEK_API_KEY` | `https://api.deepseek.com/anthropic` |
-| <img src="https://github.com/lmstudio-ai.png?size=64" alt="" width="18" height="18"> LM Studio | `lmstudio/...` | Anthropic Messages | none | `http://localhost:1234/v1` |
-| <img src="https://github.com/ggml-org.png?size=64" alt="" width="18" height="18"> llama.cpp | `llamacpp/...` | Anthropic Messages | none | `http://localhost:8080/v1` |
-| <img src="https://github.com/ollama.png?size=64" alt="" width="18" height="18"> Ollama | `ollama/...` | Anthropic Messages | none | `http://localhost:11434` |
+| <span style="white-space: nowrap;"><img src="https://cdn.simpleicons.org/nvidia/76B900" alt="" width="16" height="16"> NVIDIA NIM</span> | `nvidia_nim/...` | OpenAI chat translation | `NVIDIA_NIM_API_KEY` | `https://integrate.api.nvidia.com/v1` |
+| <span style="white-space: nowrap;"><img src="https://cdn.simpleicons.org/openrouter/6C47FF" alt="" width="16" height="16"> OpenRouter</span> | `open_router/...` | Anthropic Messages | `OPENROUTER_API_KEY` | `https://openrouter.ai/api/v1` |
+| <span style="white-space: nowrap;"><img src="https://cdn.simpleicons.org/deepseek/4D6BFF" alt="" width="16" height="16"> DeepSeek</span> | `deepseek/...` | Anthropic Messages | `DEEPSEEK_API_KEY` | `https://api.deepseek.com/anthropic` |
+| <span style="white-space: nowrap;"><img src="https://github.com/lmstudio-ai.png?size=64" alt="" width="16" height="16"> LM Studio</span> | `lmstudio/...` | Anthropic Messages | none | `http://localhost:1234/v1` |
+| <span style="white-space: nowrap;"><img src="https://github.com/ggml-org.png?size=64" alt="" width="16" height="16"> llama.cpp</span> | `llamacpp/...` | Anthropic Messages | none | `http://localhost:8080/v1` |
+| <span style="white-space: nowrap;"><img src="https://github.com/ollama.png?size=64" alt="" width="16" height="16"> Ollama</span> | `ollama/...` | Anthropic Messages | none | `http://localhost:11434` |
 
 <details>
-<summary><img src="https://cdn.simpleicons.org/nvidia/76B900" alt="" width="18" height="18"> <b>NVIDIA NIM</b></summary>
+<summary><span style="white-space: nowrap;"><img src="https://cdn.simpleicons.org/nvidia/76B900" alt="" width="16" height="16"> <b>NVIDIA NIM</b></span></summary>
 
 Get a key at [build.nvidia.com/settings/api-keys](https://build.nvidia.com/settings/api-keys).
 
@@ -150,7 +150,7 @@ Browse models at [build.nvidia.com](https://build.nvidia.com/explore/discover).
 </details>
 
 <details>
-<summary><img src="https://cdn.simpleicons.org/openrouter/6C47FF" alt="" width="18" height="18"> <b>OpenRouter</b></summary>
+<summary><span style="white-space: nowrap;"><img src="https://cdn.simpleicons.org/openrouter/6C47FF" alt="" width="16" height="16"> <b>OpenRouter</b></span></summary>
 
 Get a key at [openrouter.ai/keys](https://openrouter.ai/keys).
 
@@ -164,7 +164,7 @@ Browse [all models](https://openrouter.ai/models) or [free models](https://openr
 </details>
 
 <details>
-<summary><img src="https://cdn.simpleicons.org/deepseek/4D6BFF" alt="" width="18" height="18"> <b>DeepSeek</b></summary>
+<summary><span style="white-space: nowrap;"><img src="https://cdn.simpleicons.org/deepseek/4D6BFF" alt="" width="16" height="16"> <b>DeepSeek</b></span></summary>
 
 Get a key at [platform.deepseek.com/api_keys](https://platform.deepseek.com/api_keys).
 
@@ -178,7 +178,7 @@ This provider uses DeepSeek's Anthropic-compatible endpoint, not the OpenAI chat
 </details>
 
 <details>
-<summary><img src="https://github.com/lmstudio-ai.png?size=64" alt="" width="18" height="18"> <b>LM Studio</b></summary>
+<summary><span style="white-space: nowrap;"><img src="https://github.com/lmstudio-ai.png?size=64" alt="" width="16" height="16"> <b>LM Studio</b></span></summary>
 
 Start LM Studio's local server, load a model, then configure:
 
@@ -192,7 +192,7 @@ Use the model identifier shown by LM Studio. Prefer models with tool-use support
 </details>
 
 <details>
-<summary><img src="https://github.com/ggml-org.png?size=64" alt="" width="18" height="18"> <b>llama.cpp</b></summary>
+<summary><span style="white-space: nowrap;"><img src="https://github.com/ggml-org.png?size=64" alt="" width="16" height="16"> <b>llama.cpp</b></span></summary>
 
 Start `llama-server` with an Anthropic-compatible `/v1/messages` endpoint and enough context for Claude Code requests.
 
@@ -206,7 +206,7 @@ For local coding models, context size matters. If llama.cpp returns HTTP 400 for
 </details>
 
 <details>
-<summary><img src="https://github.com/ollama.png?size=64" alt="" width="18" height="18"> <b>Ollama</b></summary>
+<summary><span style="white-space: nowrap;"><img src="https://github.com/ollama.png?size=64" alt="" width="16" height="16"> <b>Ollama</b></span></summary>
 
 Run Ollama and pull a model:
 

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -205,10 +205,20 @@ class ProviderRegistry:
         """Fail fast unless every configured chat model exists upstream."""
         refs = settings.configured_chat_model_refs()
         refs_by_provider: dict[str, list[ConfiguredChatModelRef]] = defaultdict(list)
-        for ref in refs:
-            refs_by_provider[ref.provider_id].append(ref)
-
         failures: list[str] = []
+        for ref in refs:
+            if ref.provider_id == "nvidia_nim" and "/" not in ref.model_id:
+                failures.append(
+                    _format_model_validation_failure(
+                        ref,
+                        f"NIM model names require a vendor prefix "
+                        f"(e.g. 'google/{ref.model_id}'). "
+                        f"Browse models at https://build.nvidia.com/explore/discover",
+                    )
+                )
+            else:
+                refs_by_provider[ref.provider_id].append(ref)
+
         tasks: dict[str, asyncio.Task[frozenset[str]]] = {}
         for provider_id, provider_refs in refs_by_provider.items():
             try:

--- a/tests/providers/test_model_validation.py
+++ b/tests/providers/test_model_validation.py
@@ -22,7 +22,7 @@ from providers.registry import ProviderRegistry
 
 def _settings(
     *,
-    model: str = "nvidia_nim/nim-model",
+    model: str = "nvidia_nim/org/nim-model",
     model_opus: str | None = None,
     model_sonnet: str | None = None,
     model_haiku: str | None = None,
@@ -196,7 +196,7 @@ class FakeProvider(BaseProvider):
 async def test_registry_validation_succeeds_for_all_configured_models() -> None:
     registry = ProviderRegistry(
         {
-            "nvidia_nim": FakeProvider(frozenset({"nim-model"})),
+            "nvidia_nim": FakeProvider(frozenset({"org/nim-model"})),
             "open_router": FakeProvider(frozenset({"anthropic/claude-opus"})),
         }
     )
@@ -208,9 +208,9 @@ async def test_registry_validation_succeeds_for_all_configured_models() -> None:
 @pytest.mark.asyncio
 async def test_registry_validation_reports_missing_model_with_sources() -> None:
     registry = ProviderRegistry(
-        {"nvidia_nim": FakeProvider(frozenset({"different-model"}))}
+        {"nvidia_nim": FakeProvider(frozenset({"org/different-model"}))}
     )
-    settings = _settings(model_sonnet="nvidia_nim/nim-model")
+    settings = _settings(model_sonnet="nvidia_nim/org/nim-model")
 
     with pytest.raises(ServiceUnavailableError) as exc_info:
         await registry.validate_configured_models(settings)
@@ -218,7 +218,7 @@ async def test_registry_validation_reports_missing_model_with_sources() -> None:
     message = exc_info.value.message
     assert "sources=MODEL,MODEL_SONNET" in message
     assert "provider=nvidia_nim" in message
-    assert "model=nim-model" in message
+    assert "model=org/nim-model" in message
     assert "problem=missing model" in message
 
 
@@ -226,7 +226,7 @@ async def test_registry_validation_reports_missing_model_with_sources() -> None:
 async def test_registry_validation_aggregates_multiple_failures() -> None:
     registry = ProviderRegistry(
         {
-            "nvidia_nim": FakeProvider(frozenset({"different-model"})),
+            "nvidia_nim": FakeProvider(frozenset({"org/different-model"})),
             "open_router": FakeProvider(
                 error=ModelListResponseError("bad model-list shape")
             ),
@@ -238,7 +238,7 @@ async def test_registry_validation_aggregates_multiple_failures() -> None:
         await registry.validate_configured_models(settings)
 
     message = exc_info.value.message
-    assert "sources=MODEL provider=nvidia_nim model=nim-model" in message
+    assert "sources=MODEL provider=nvidia_nim model=org/nim-model" in message
     assert "problem=missing model" in message
     assert "sources=MODEL_OPUS provider=open_router model=anthropic/claude-opus" in (
         message
@@ -253,7 +253,7 @@ async def test_registry_validation_queries_providers_concurrently() -> None:
     registry = ProviderRegistry(
         {
             "nvidia_nim": FakeProvider(
-                frozenset({"nim-model"}),
+                frozenset({"org/nim-model"}),
                 started=nim_started,
                 peer_started=router_started,
             ),
@@ -267,3 +267,26 @@ async def test_registry_validation_queries_providers_concurrently() -> None:
     settings = _settings(model_opus="open_router/anthropic/claude-opus")
 
     await asyncio.wait_for(registry.validate_configured_models(settings), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_registry_validation_rejects_nim_model_without_vendor_prefix() -> None:
+    registry = ProviderRegistry({"nvidia_nim": FakeProvider(frozenset({"google/gemma-3-27b-it"}))})
+    settings = _settings(model="nvidia_nim/gemma-3-27b-it")
+
+    with pytest.raises(ServiceUnavailableError) as exc_info:
+        await registry.validate_configured_models(settings)
+
+    message = exc_info.value.message
+    assert "provider=nvidia_nim" in message
+    assert "model=gemma-3-27b-it" in message
+    assert "vendor prefix" in message
+    assert "build.nvidia.com" in message
+
+
+@pytest.mark.asyncio
+async def test_registry_validation_accepts_nim_model_with_vendor_prefix() -> None:
+    registry = ProviderRegistry({"nvidia_nim": FakeProvider(frozenset({"google/gemma-3-27b-it"}))})
+    settings = _settings(model="nvidia_nim/google/gemma-3-27b-it")
+
+    await registry.validate_configured_models(settings)

--- a/tests/providers/test_model_validation.py
+++ b/tests/providers/test_model_validation.py
@@ -271,7 +271,9 @@ async def test_registry_validation_queries_providers_concurrently() -> None:
 
 @pytest.mark.asyncio
 async def test_registry_validation_rejects_nim_model_without_vendor_prefix() -> None:
-    registry = ProviderRegistry({"nvidia_nim": FakeProvider(frozenset({"google/gemma-3-27b-it"}))})
+    registry = ProviderRegistry(
+        {"nvidia_nim": FakeProvider(frozenset({"google/gemma-3-27b-it"}))}
+    )
     settings = _settings(model="nvidia_nim/gemma-3-27b-it")
 
     with pytest.raises(ServiceUnavailableError) as exc_info:
@@ -286,7 +288,9 @@ async def test_registry_validation_rejects_nim_model_without_vendor_prefix() -> 
 
 @pytest.mark.asyncio
 async def test_registry_validation_accepts_nim_model_with_vendor_prefix() -> None:
-    registry = ProviderRegistry({"nvidia_nim": FakeProvider(frozenset({"google/gemma-3-27b-it"}))})
+    registry = ProviderRegistry(
+        {"nvidia_nim": FakeProvider(frozenset({"google/gemma-3-27b-it"}))}
+    )
     settings = _settings(model="nvidia_nim/google/gemma-3-27b-it")
 
     await registry.validate_configured_models(settings)


### PR DESCRIPTION
## Problem

When a user sets `MODEL=nvidia_nim/gemma-3-27b-it` (no vendor prefix), the request reaches NIM and returns a 404 which surfaces as an opaque provider error. The user has no idea what went wrong or how to fix it.

## Fix

Added a format check to the existing startup model validation (`validate_configured_models`). If a NIM model name has no `/`, validation fails immediately with a clear message before any request is made:

```
problem=NIM model names require a vendor prefix (e.g. 'google/gemma-3-27b-it').
Browse models at https://build.nvidia.com/explore/discover
```

No auto-resolution, no API calls, no magic — just an early, actionable error.

## Files changed

- `providers/registry.py` — pre-check in `validate_configured_models` for NIM refs missing a vendor prefix
- `tests/providers/test_model_validation.py` — 2 new tests (rejects missing prefix, accepts valid prefix); updated existing fixtures to use properly prefixed NIM model names

## Test plan
- [x] `uv run pytest tests/providers/test_model_validation.py` — 12 passed