### PR TITLE
Fix Python 3.14 Pydantic typing crash

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,23 +1,28 @@
 """FastAPI application factory and configuration."""
 
+from __future__ import annotations
+
 import traceback
 from contextlib import asynccontextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from fastapi import FastAPI, Request
-from fastapi.exception_handlers import request_validation_exception_handler
-from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
 from loguru import logger
 from starlette.types import Receive, Scope, Send
 
 from config.logging_config import configure_logging
 from config.settings import get_settings
+from core.typing_compat import patch_typing_eval_type_for_pydantic
 from providers.exceptions import ProviderError
 
 from .routes import router
 from .runtime import AppRuntime, startup_failure_message
 from .validation_log import summarize_request_validation_body
+
+patch_typing_eval_type_for_pydantic()
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI, Request
+    from fastapi.exceptions import RequestValidationError
 
 
 @asynccontextmanager
@@ -81,6 +86,11 @@ class GracefulLifespanApp:
 
 def create_app(*, lifespan_enabled: bool = True) -> FastAPI:
     """Create and configure the FastAPI application."""
+    from fastapi import FastAPI
+    from fastapi.exception_handlers import request_validation_exception_handler
+    from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import JSONResponse
+
     settings = get_settings()
     configure_logging(
         settings.log_file, verbose_third_party=settings.log_raw_api_payloads

--- a/core/typing_compat.py
+++ b/core/typing_compat.py
@@ -1,0 +1,54 @@
+"""Small runtime compatibility shims.
+
+Python 3.14 changed the private signature of ``typing._eval_type`` and removed
+the ``prefer_fwd_module`` keyword argument.
+
+Pydantic (and therefore FastAPI) may still pass that keyword, which causes an
+import-time crash. We apply a small wrapper to drop the unsupported kwarg.
+"""
+
+import inspect
+import typing
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, cast
+
+_TYPING_EVAL_TYPE_PATCHED = False
+
+
+def patch_typing_eval_type_for_pydantic() -> None:
+    """Allow Pydantic to run on Python 3.14 by dropping ``prefer_fwd_module``.
+
+    Python 3.14 removed ``prefer_fwd_module`` from ``typing._eval_type``.
+    Pydantic 2.13.3 still passes it, raising ``TypeError`` during FastAPI
+    import. This function wraps ``typing._eval_type`` to accept and ignore the
+    keyword.
+    """
+
+    global _TYPING_EVAL_TYPE_PATCHED
+    if _TYPING_EVAL_TYPE_PATCHED:
+        return
+
+    eval_type_obj = getattr(typing, "_eval_type", None)
+    if eval_type_obj is None:
+        _TYPING_EVAL_TYPE_PATCHED = True
+        return
+
+    try:
+        sig = inspect.signature(eval_type_obj)
+    except TypeError, ValueError:
+        return
+
+    if "prefer_fwd_module" in sig.parameters:
+        _TYPING_EVAL_TYPE_PATCHED = True
+        return
+
+    original_eval_type = cast(Callable[..., Any], eval_type_obj)
+
+    @wraps(original_eval_type)
+    def _eval_type_patched(*args: Any, **kwargs: Any) -> Any:
+        kwargs.pop("prefer_fwd_module", None)
+        return original_eval_type(*args, **kwargs)
+
+    typing.__dict__["_eval_type"] = _eval_type_patched
+    _TYPING_EVAL_TYPE_PATCHED = True

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,12 @@
+"""Interpreter startup tweaks for the repository.
+
+Python automatically imports ``sitecustomize`` (if present on ``sys.path``)
+during interpreter startup.
+
+We use it to apply a small Python 3.14 compatibility shim required for the
+current FastAPI/Pydantic dependency set.
+"""
+
+from core.typing_compat import patch_typing_eval_type_for_pydantic
+
+patch_typing_eval_type_for_pydantic()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from config.settings import Settings
+from core.typing_compat import patch_typing_eval_type_for_pydantic
 
 # Set mock environment BEFORE any imports that use Settings
 os.environ.setdefault("NVIDIA_NIM_API_KEY", "test_key")
@@ -18,6 +19,8 @@ os.environ["PTB_TIMEDELTA"] = "1"
 os.environ["ANTHROPIC_AUTH_TOKEN"] = ""
 
 Settings.model_config = {**Settings.model_config, "env_file": None}
+
+patch_typing_eval_type_for_pydantic()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Problem\nRunning the server (or importing FastAPI/Pydantic models) on Python 3.14 fails at import time with:\n\n\TypeError: _eval_type() got an unexpected keyword argument 'prefer_fwd_module'\\n\nPython 3.14 removed the private keyword argument \prefer_fwd_module\ from \	yping._eval_type\, but Pydantic/FastAPI still pass it.\n\n### Fix\n- Add a small runtime shim that wraps \	yping._eval_type\ and drops \prefer_fwd_module\ when unsupported.\n- Apply the shim at interpreter startup via \sitecustomize.py\ so it runs before Pydantic imports (needed for pytest/pydantic-settings too).\n- Also apply it in the API factory module for extra safety.\n\n### Verification\n- \uv run ruff format\, \uv run ruff check\, \uv run ty check\\n- \uv run pytest\ (1186 passed)\n- \uv run uvicorn server:app --host 127.0.0.1 --port 8082\ starts successfully on Python 3.14\n