### PR TITLE
feat: MAX_MESSAGES + CONTEXT_MAX_TOKENS (tool-aware, seam-safe) + NIM_PARALLEL_TOOL_CALLS + SSE fix + Claude 4 IDs + tool schema hint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
 # Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "ollama"
+# MODEL="open_router/tencent/hy3-preview:free"
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=

--- a/INICIAR_CLAUDE_GRATIS.bat
+++ b/INICIAR_CLAUDE_GRATIS.bat
@@ -1,0 +1,37 @@
+@echo off
+title Claude Code Gratis (NIM Proxy)
+color 0A
+
+echo.
+echo  ==========================================
+echo   CLAUDE CODE GRATIS - NVIDIA NIM
+echo  ==========================================
+echo.
+
+REM Verificar si el proxy ya esta corriendo
+curl -s http://localhost:3000/health >nul 2>&1
+if %errorlevel% equ 0 (
+    echo  [OK] Proxy ya esta corriendo
+    goto :iniciar_claude
+)
+
+echo  Iniciando servidor proxy...
+start "NIM Proxy" /min cmd /c "cd /d C:\Users\titan\free-claude-code && uv run python server.py"
+
+echo  Esperando que el proxy arranque...
+:esperar
+timeout /t 2 /nobreak >nul
+curl -s http://localhost:3000/health >nul 2>&1
+if %errorlevel% neq 0 goto :esperar
+
+:iniciar_claude
+echo  [OK] Proxy activo en localhost:3000
+echo  Modelo: Llama 3.1 70B (NVIDIA NIM - GRATIS)
+echo.
+echo  Iniciando Claude Code...
+echo.
+
+set ANTHROPIC_BASE_URL=http://localhost:3000
+set ANTHROPIC_AUTH_TOKEN=freecc
+
+claude

--- a/INICIAR_CLAUDE_GRATIS.bat
+++ b/INICIAR_CLAUDE_GRATIS.bat
@@ -26,7 +26,7 @@ if %errorlevel% neq 0 goto :esperar
 
 :iniciar_claude
 echo  [OK] Proxy activo en localhost:3000
-echo  Modelo: Llama 3.1 70B (NVIDIA NIM - GRATIS)
+echo  Modelo: Llama 3.1 8B (NVIDIA NIM - GRATIS)
 echo.
 echo  Iniciando Claude Code...
 echo.

--- a/api/model_router.py
+++ b/api/model_router.py
@@ -50,7 +50,9 @@ class ModelRouter:
             thinking_enabled = (
                 force_thinking_enabled
                 if force_thinking_enabled is not None
-                else self._settings.resolve_thinking(direct_provider_model)
+                else self._settings.resolve_thinking(
+                    direct_provider_model, provider_id=direct_provider_id
+                )
             )
             logger.debug(
                 "MODEL DIRECT: '{}' -> provider='{}' model='{}' thinking={}",
@@ -68,9 +70,11 @@ class ModelRouter:
             )
 
         provider_model_ref = self._settings.resolve_model(claude_model_name)
-        thinking_enabled = self._settings.resolve_thinking(claude_model_name)
         provider_id = Settings.parse_provider_type(provider_model_ref)
         provider_model = Settings.parse_model_name(provider_model_ref)
+        thinking_enabled = self._settings.resolve_thinking(
+            claude_model_name, provider_id=provider_id
+        )
         if provider_model != claude_model_name:
             logger.debug(
                 "MODEL MAPPING: '{}' -> '{}'", claude_model_name, provider_model

--- a/api/routes.py
+++ b/api/routes.py
@@ -20,6 +20,23 @@ DISCOVERED_MODEL_CREATED_AT = "1970-01-01T00:00:00Z"
 
 
 SUPPORTED_CLAUDE_MODELS = [
+    # Claude 4 family (current)
+    ModelResponse(
+        id="claude-opus-4-7",
+        display_name="Claude Opus 4.7",
+        created_at="2025-10-01T00:00:00Z",
+    ),
+    ModelResponse(
+        id="claude-sonnet-4-6",
+        display_name="Claude Sonnet 4.6",
+        created_at="2025-10-01T00:00:00Z",
+    ),
+    ModelResponse(
+        id="claude-haiku-4-5-20251001",
+        display_name="Claude Haiku 4.5",
+        created_at="2025-10-01T00:00:00Z",
+    ),
+    # Claude 4 family (legacy date-suffix IDs)
     ModelResponse(
         id="claude-opus-4-20250514",
         display_name="Claude Opus 4",
@@ -35,6 +52,7 @@ SUPPORTED_CLAUDE_MODELS = [
         display_name="Claude Haiku 4",
         created_at="2025-05-14T00:00:00Z",
     ),
+    # Claude 3.x family
     ModelResponse(
         id="claude-3-opus-20240229",
         display_name="Claude 3 Opus",

--- a/api/services.py
+++ b/api/services.py
@@ -103,6 +103,19 @@ class ClaudeProxyService:
         try:
             _require_non_empty_messages(request_data.messages)
 
+            max_msgs = self._settings.max_messages
+            if max_msgs > 0 and len(request_data.messages) > max_msgs:
+                trimmed = request_data.messages[-max_msgs:]
+                while trimmed and trimmed[0].role != "user":
+                    trimmed = trimmed[1:]
+                if trimmed:
+                    logger.info(
+                        "AUTO_TRIM: reduced {} -> {} messages",
+                        len(request_data.messages),
+                        len(trimmed),
+                    )
+                    request_data = request_data.model_copy(update={"messages": trimmed})
+
             routed = self._model_router.resolve_messages_request(request_data)
             if routed.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:
                 tool_err = openai_chat_upstream_server_tool_error(

--- a/api/services.py
+++ b/api/services.py
@@ -107,7 +107,7 @@ class ClaudeProxyService:
             # Apply context management (trimming/compaction) if configured
             context_mgr = get_context_manager(self._settings)
             messages, was_trimmed = context_mgr.trim_messages(
-                request_data.messages, request_data.system
+                request_data.messages, request_data.system, request_data.tools
             )
             if was_trimmed:
                 logger.info(

--- a/api/services.py
+++ b/api/services.py
@@ -14,6 +14,7 @@ from loguru import logger
 from config.settings import Settings
 from core.anthropic import get_token_count, get_user_facing_error_message
 from core.anthropic.sse import ANTHROPIC_SSE_RESPONSE_HEADERS
+from core.context_manager import get_context_manager
 from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
 
@@ -103,20 +104,25 @@ class ClaudeProxyService:
         try:
             _require_non_empty_messages(request_data.messages)
 
-            max_msgs = self._settings.max_messages
-            if max_msgs > 0 and len(request_data.messages) > max_msgs:
-                trimmed = request_data.messages[-max_msgs:]
-                while trimmed and trimmed[0].role != "user":
-                    trimmed = trimmed[1:]
-                if trimmed:
-                    logger.info(
-                        "AUTO_TRIM: reduced {} -> {} messages",
-                        len(request_data.messages),
-                        len(trimmed),
-                    )
-                    request_data = request_data.model_copy(update={"messages": trimmed})
+            # Apply context management (trimming/compaction) if configured
+            context_mgr = get_context_manager(self._settings)
+            messages, was_trimmed = context_mgr.trim_messages(
+                request_data.messages, request_data.system
+            )
+            if was_trimmed:
+                logger.info(
+                    "CONTEXT: trimmed {} → {} messages",
+                    len(request_data.messages),
+                    len(messages),
+                )
 
-            routed = self._model_router.resolve_messages_request(request_data)
+            trimmed_request = (
+                request_data.model_copy(update={"messages": messages})
+                if was_trimmed
+                else request_data
+            )
+
+            routed = self._model_router.resolve_messages_request(trimmed_request)
             if routed.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:
                 tool_err = openai_chat_upstream_server_tool_error(
                     routed.request,

--- a/api/services.py
+++ b/api/services.py
@@ -104,25 +104,31 @@ class ClaudeProxyService:
         try:
             _require_non_empty_messages(request_data.messages)
 
-            # Apply context management (trimming/compaction) if configured
-            context_mgr = get_context_manager(self._settings)
+            # Resolve routing first so context-trim uses the right provider's
+            # budget (NIM/OR have different caps; see config.settings).
+            routed = self._model_router.resolve_messages_request(request_data)
+            provider_id = routed.resolved.provider_id
+
+            # Apply provider-scoped context management.
+            context_mgr = get_context_manager(self._settings, provider_id=provider_id)
             messages, was_trimmed = context_mgr.trim_messages(
-                request_data.messages, request_data.system, request_data.tools
+                routed.request.messages, routed.request.system, routed.request.tools
             )
             if was_trimmed:
                 logger.info(
-                    "CONTEXT: trimmed {} → {} messages",
-                    len(request_data.messages),
+                    "CONTEXT: trimmed {} → {} messages (provider={})",
+                    len(routed.request.messages),
                     len(messages),
+                    provider_id,
                 )
+                # Rebuild routed with the trimmed messages — every downstream
+                # consumer reads from routed.request, so this keeps them in sync.
+                from api.model_router import RoutedMessagesRequest
 
-            trimmed_request = (
-                request_data.model_copy(update={"messages": messages})
-                if was_trimmed
-                else request_data
-            )
-
-            routed = self._model_router.resolve_messages_request(trimmed_request)
+                routed = RoutedMessagesRequest(
+                    request=routed.request.model_copy(update={"messages": messages}),
+                    resolved=routed.resolved,
+                )
             if routed.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:
                 tool_err = openai_chat_upstream_server_tool_error(
                     routed.request,

--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -93,10 +93,8 @@ def configure_logging(
     # Remove default loguru handler (writes to stderr)
     logger.remove()
 
-    # Truncate log file on fresh start for clean debugging
-    Path(log_file).write_text("")
-
     # Add file sink: JSON lines, DEBUG level, context vars at top level
+    # enqueue=True: async writes — decouples log I/O from request path
     logger.add(
         log_file,
         level="DEBUG",
@@ -104,6 +102,7 @@ def configure_logging(
         encoding="utf-8",
         mode="a",
         rotation="50 MB",
+        enqueue=True,
     )
 
     # Intercept stdlib logging: route all root logger output to loguru

--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -8,8 +8,8 @@ included at top level for easy grep/filter.
 
 import json
 import logging
+import os
 import re
-from pathlib import Path
 
 from loguru import logger
 
@@ -93,11 +93,11 @@ def configure_logging(
     # Remove default loguru handler (writes to stderr)
     logger.remove()
 
-    # Add file sink: JSON lines, DEBUG level, context vars at top level
-    # enqueue=True: async writes — decouples log I/O from request path
+    # Add file sink: JSON lines, INFO by default (DEBUG via LOG_FILE_LEVEL=DEBUG).
+    # enqueue=True offloads writes to a background thread, keeping the streaming path non-blocking.
     logger.add(
         log_file,
-        level="DEBUG",
+        level=os.getenv("LOG_FILE_LEVEL", "INFO"),
         format=_serialize_with_context,
         encoding="utf-8",
         mode="a",

--- a/config/settings.py
+++ b/config/settings.py
@@ -198,6 +198,12 @@ class Settings(BaseSettings):
     # ==================== Fast Prefix Detection ====================
     fast_prefix_detection: bool = True
 
+    # ==================== Message Truncation ====================
+    # When > 0, requests with more messages than this are trimmed to the last N before
+    # forwarding to the provider. Prevents timeouts on free-tier inference (e.g. NIM).
+    # 0 = disabled. Recommended: 120 for NVIDIA NIM free tier.
+    max_messages: int = Field(default=0, validation_alias="MAX_MESSAGES")
+
     # ==================== Optimizations ====================
     enable_network_probe_mock: bool = True
     enable_title_generation_skip: bool = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -198,12 +198,6 @@ class Settings(BaseSettings):
     # ==================== Fast Prefix Detection ====================
     fast_prefix_detection: bool = True
 
-    # ==================== Message Truncation ====================
-    # When > 0, requests with more messages than this are trimmed to the last N before
-    # forwarding to the provider. Prevents timeouts on free-tier inference (e.g. NIM).
-    # 0 = disabled. Recommended: 120 for NVIDIA NIM free tier.
-    max_messages: int = Field(default=0, validation_alias="MAX_MESSAGES")
-
     # ==================== Optimizations ====================
     enable_network_probe_mock: bool = True
     enable_title_generation_skip: bool = True
@@ -254,6 +248,10 @@ class Settings(BaseSettings):
     debug_subagent_stack: bool = Field(
         default=False, validation_alias="DEBUG_SUBAGENT_STACK"
     )
+
+    # ==================== Context Management ====================
+    max_messages: int = Field(default=0, validation_alias="MAX_MESSAGES")
+    context_max_tokens: int = Field(default=0, validation_alias="CONTEXT_MAX_TOKENS")
 
     # ==================== NIM Settings ====================
     nim: NimSettings = Field(default_factory=NimSettings)
@@ -407,7 +405,7 @@ class Settings(BaseSettings):
         return v
 
     @model_validator(mode="after")
-    def check_nvidia_nim_api_key(self) -> Settings:
+    def check_nvidia_nim_api_key(self) -> "Settings":
         if (
             self.voice_note_enabled
             and self.whisper_device == "nvidia_nim"
@@ -420,7 +418,7 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def prefer_dotenv_anthropic_auth_token(self) -> Settings:
+    def prefer_dotenv_anthropic_auth_token(self) -> "Settings":
         """Let explicit .env auth config override stale shell/client tokens."""
         dotenv_value = _env_file_override(self.model_config, "ANTHROPIC_AUTH_TOKEN")
         if dotenv_value is not None:

--- a/config/settings.py
+++ b/config/settings.py
@@ -255,6 +255,12 @@ class Settings(BaseSettings):
 
     # ==================== NIM Settings ====================
     nim: NimSettings = Field(default_factory=NimSettings)
+    nim_enable_thinking: bool = Field(
+        default=False, validation_alias="NIM_ENABLE_THINKING"
+    )
+    nim_parallel_tool_calls: bool = Field(
+        default=True, validation_alias="NIM_PARALLEL_TOOL_CALLS"
+    )
 
     # ==================== Voice Note Transcription ====================
     voice_note_enabled: bool = Field(
@@ -403,6 +409,15 @@ class Settings(BaseSettings):
             supported = ", ".join(f"'{p}'" for p in SUPPORTED_PROVIDER_IDS)
             raise ValueError(f"Invalid provider: '{provider}'. Supported: {supported}")
         return v
+
+    @model_validator(mode="after")
+    def _inject_nim_settings(self) -> "Settings":
+        self.nim = self.nim.model_copy(
+            update={
+                "parallel_tool_calls": self.nim_parallel_tool_calls,
+            }
+        )
+        return self
 
     @model_validator(mode="after")
     def check_nvidia_nim_api_key(self) -> "Settings":

--- a/config/settings.py
+++ b/config/settings.py
@@ -252,6 +252,7 @@ class Settings(BaseSettings):
     # ==================== Context Management ====================
     max_messages: int = Field(default=0, validation_alias="MAX_MESSAGES")
     context_max_tokens: int = Field(default=0, validation_alias="CONTEXT_MAX_TOKENS")
+    context_min_messages: int = Field(default=20, validation_alias="CONTEXT_MIN_MESSAGES")
 
     # ==================== NIM Settings ====================
     nim: NimSettings = Field(default_factory=NimSettings)

--- a/config/settings.py
+++ b/config/settings.py
@@ -109,6 +109,9 @@ class Settings(BaseSettings):
     # ==================== OpenRouter Config ====================
     open_router_api_key: str = Field(default="", validation_alias="OPENROUTER_API_KEY")
 
+    # ==================== Hugging Face Router Config ====================
+    hf_token: str = Field(default="", validation_alias="HF_TOKEN")
+
     # ==================== DeepSeek Config ====================
     deepseek_api_key: str = Field(default="", validation_alias="DEEPSEEK_API_KEY")
 
@@ -159,6 +162,7 @@ class Settings(BaseSettings):
     # ==================== Per-Provider Proxy ====================
     nvidia_nim_proxy: str = Field(default="", validation_alias="NVIDIA_NIM_PROXY")
     open_router_proxy: str = Field(default="", validation_alias="OPENROUTER_PROXY")
+    huggingface_proxy: str = Field(default="", validation_alias="HUGGINGFACE_PROXY")
     lmstudio_proxy: str = Field(default="", validation_alias="LMSTUDIO_PROXY")
     llamacpp_proxy: str = Field(default="", validation_alias="LLAMACPP_PROXY")
 
@@ -250,9 +254,28 @@ class Settings(BaseSettings):
     )
 
     # ==================== Context Management ====================
+    # Global defaults — per-provider overrides below win when set (>0 / non-empty).
     max_messages: int = Field(default=0, validation_alias="MAX_MESSAGES")
     context_max_tokens: int = Field(default=0, validation_alias="CONTEXT_MAX_TOKENS")
     context_min_messages: int = Field(default=20, validation_alias="CONTEXT_MIN_MESSAGES")
+
+    # Per-provider context overrides. 0 = inherit the global setting above.
+    nim_max_messages: int = Field(default=0, validation_alias="NIM_MAX_MESSAGES")
+    nim_context_max_tokens: int = Field(
+        default=0, validation_alias="NIM_CONTEXT_MAX_TOKENS"
+    )
+    nim_context_min_messages: int = Field(
+        default=0, validation_alias="NIM_CONTEXT_MIN_MESSAGES"
+    )
+    openrouter_max_messages: int = Field(
+        default=0, validation_alias="OPENROUTER_MAX_MESSAGES"
+    )
+    openrouter_context_max_tokens: int = Field(
+        default=0, validation_alias="OPENROUTER_CONTEXT_MAX_TOKENS"
+    )
+    openrouter_context_min_messages: int = Field(
+        default=0, validation_alias="OPENROUTER_CONTEXT_MIN_MESSAGES"
+    )
 
     # ==================== NIM Settings ====================
     nim: NimSettings = Field(default_factory=NimSettings)
@@ -261,6 +284,14 @@ class Settings(BaseSettings):
     )
     nim_parallel_tool_calls: bool = Field(
         default=True, validation_alias="NIM_PARALLEL_TOOL_CALLS"
+    )
+
+    # ==================== OpenRouter Settings ====================
+    # Set true to enable thinking/reasoning mode for OR requests (overrides
+    # global ENABLE_MODEL_THINKING for OR-routed requests only).  Useful when
+    # you pick a Qwen ``-thinking`` variant from the /model menu.
+    openrouter_enable_thinking: bool = Field(
+        default=False, validation_alias="OPENROUTER_ENABLE_THINKING"
     )
 
     # ==================== Voice Note Transcription ====================
@@ -412,7 +443,7 @@ class Settings(BaseSettings):
         return v
 
     @model_validator(mode="after")
-    def _inject_nim_settings(self) -> "Settings":
+    def _inject_nim_settings(self) -> Settings:
         self.nim = self.nim.model_copy(
             update={
                 "parallel_tool_calls": self.nim_parallel_tool_calls,
@@ -421,7 +452,7 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def check_nvidia_nim_api_key(self) -> "Settings":
+    def check_nvidia_nim_api_key(self) -> Settings:
         if (
             self.voice_note_enabled
             and self.whisper_device == "nvidia_nim"
@@ -434,7 +465,7 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
-    def prefer_dotenv_anthropic_auth_token(self) -> "Settings":
+    def prefer_dotenv_anthropic_auth_token(self) -> Settings:
         """Let explicit .env auth config override stale shell/client tokens."""
         dotenv_value = _env_file_override(self.model_config, "ANTHROPIC_AUTH_TOKEN")
         if dotenv_value is not None:
@@ -496,15 +527,34 @@ class Settings(BaseSettings):
             for model_ref, sources in sources_by_ref.items()
         )
 
-    def resolve_thinking(self, claude_model_name: str) -> bool:
-        """Resolve whether thinking is enabled for an incoming Claude model name."""
+    def resolve_thinking(
+        self, claude_model_name: str, provider_id: str | None = None
+    ) -> bool:
+        """Resolve whether thinking is enabled for an incoming Claude model name.
+
+        Resolution order: per-role override → provider-specific override →
+        model-name heuristic (``-thinking`` variant) → global default.
+        """
         name_lower = claude_model_name.lower()
+
+        # Per-role overrides (Opus/Sonnet/Haiku) win first when explicitly set.
         if "opus" in name_lower and self.enable_opus_thinking is not None:
             return self.enable_opus_thinking
         if "haiku" in name_lower and self.enable_haiku_thinking is not None:
             return self.enable_haiku_thinking
         if "sonnet" in name_lower and self.enable_sonnet_thinking is not None:
             return self.enable_sonnet_thinking
+
+        # Provider-specific overrides (new): tune NIM and OR independently.
+        if provider_id == "nvidia_nim" and self.nim_enable_thinking:
+            return True
+        if provider_id == "open_router":
+            # Qwen ``-thinking`` variants on OR expect reasoning mode by name.
+            if "thinking" in name_lower:
+                return True
+            if self.openrouter_enable_thinking:
+                return True
+
         return self.enable_model_thinking
 
     def web_fetch_allowed_scheme_set(self) -> frozenset[str]:

--- a/core/anthropic/conversion.py
+++ b/core/anthropic/conversion.py
@@ -10,6 +10,11 @@ from pydantic import BaseModel
 from .content import get_block_attr, get_block_type
 from .utils import set_if_not_none
 
+_TOOL_USE_HINT = (
+    "When calling tools, you MUST include ALL required parameters listed in each "
+    "tool's input_schema. Never omit a required parameter."
+)
+
 
 class OpenAIConversionError(Exception):
     """Raised when Anthropic content cannot be converted to OpenAI chat without data loss."""
@@ -583,6 +588,10 @@ def build_base_request_body(
     tools = getattr(request_data, "tools", None)
     if tools:
         body["tools"] = AnthropicToOpenAIConverter.convert_tools(tools)
+        if messages and messages[0].get("role") == "system":
+            messages[0]["content"] = messages[0]["content"] + "\n\n" + _TOOL_USE_HINT
+        else:
+            messages.insert(0, {"role": "system", "content": _TOOL_USE_HINT})
     tool_choice = getattr(request_data, "tool_choice", None)
     if tool_choice:
         body["tool_choice"] = AnthropicToOpenAIConverter.convert_tool_choice(

--- a/core/anthropic/emitted_sse_tracker.py
+++ b/core/anthropic/emitted_sse_tracker.py
@@ -15,25 +15,37 @@ class EmittedNativeSseTracker:
     """Parse emitted SSE frames so mid-stream errors can close blocks and pick a fresh index."""
 
     def __init__(self) -> None:
-        self._buf = ""
+        self._chunks: list[str] = []
         self._open_stack: list[int] = []
         self._max_index = -1
         self.message_id: str | None = None
         self.model: str = ""
+        self._buf: str | None = None
 
     def feed(self, chunk: str) -> None:
         """Record SSE frames completed by ``chunk`` (handles splitting across reads)."""
-        self._buf += chunk
+        self._chunks.append(chunk)
+        self._buf = None  # invalidate cached join
         while True:
-            sep = self._buf.find("\n\n")
+            buf = self._get_buf()
+            sep = buf.find("\n\n")
             if sep < 0:
                 break
-            frame = self._buf[:sep]
-            self._buf = self._buf[sep + 2 :]
+            frame = buf[:sep]
+            self._set_buf(buf[sep + 2 :])
             if not frame.strip():
                 continue
             for event in parse_sse_lines(frame.splitlines()):
                 self._observe(event)
+
+    def _get_buf(self) -> str:
+        if self._buf is None:
+            self._buf = "".join(self._chunks)
+        return self._buf
+
+    def _set_buf(self, value: str) -> None:
+        self._buf = value
+        self._chunks = [value]
 
     def _observe(self, event: SSEEvent) -> None:
         if event.event == "message_start":

--- a/core/anthropic/sse.py
+++ b/core/anthropic/sse.py
@@ -187,12 +187,6 @@ class SSEBuilder:
         event_str = format_sse_event(event_type, data)
         if self._log_raw_events:
             logger.debug("SSE_EVENT: {} - {}", event_type, event_str.strip())
-        else:
-            logger.debug(
-                "SSE_EVENT: event_type={} serialized_bytes={}",
-                event_type,
-                len(event_str.encode("utf-8")),
-            )
         return event_str
 
     def message_start(self) -> str:

--- a/core/anthropic/tokens.py
+++ b/core/anthropic/tokens.py
@@ -96,7 +96,7 @@ def get_token_count(
                     )
                     try:
                         total_tokens += len(ENCODER.encode(json.dumps(block)))
-                    except TypeError, ValueError:
+                    except (TypeError, ValueError):
                         total_tokens += len(ENCODER.encode(str(block)))
 
     if tools:

--- a/core/anthropic/tools.py
+++ b/core/anthropic/tools.py
@@ -35,6 +35,11 @@ class HeuristicToolParser:
     _WEB_TOOL_JSON_PATTERN = re.compile(
         r"(?is)\b(?:use\s+)?(?P<tool>WebFetch|WebSearch)\b.*?(?P<json>\{.*?\})"
     )
+    # Matches: ● {"type": "function", "name": "Foo", "parameters": {...}}
+    # emitted by some OpenAI-compat models (e.g. llama-4-maverick via NIM)
+    _BULLET_FUNC_JSON_PATTERN = re.compile(
+        r"●\s*(\{[^{}]*\"type\"\s*:\s*\"function\"[^{}]*\"name\"\s*:\s*\"(?P<name>[^\"]+)\"[^{}]*\"parameters\"\s*:\s*(?P<params>\{[^{}]*\})[^{}]*\})"
+    )
 
     def __init__(self):
         self._state = ParserState.TEXT
@@ -42,6 +47,35 @@ class HeuristicToolParser:
         self._current_tool_id = None
         self._current_function_name = None
         self._current_parameters = {}
+
+    def _extract_bullet_func_json_calls(self) -> tuple[str, list[dict[str, Any]]]:
+        """Detect ● {"type": "function", "name": "...", "parameters": {...}} style."""
+        detected_tools: list[dict[str, Any]] = []
+        remaining = self._buffer
+
+        for match in self._BULLET_FUNC_JSON_PATTERN.finditer(self._buffer):
+            try:
+                params = json.loads(match.group("params"))
+            except json.JSONDecodeError:
+                params = {}
+            tool_name = match.group("name")
+            detected_tools.append(
+                {
+                    "type": "tool_use",
+                    "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
+                    "name": tool_name,
+                    "input": params if isinstance(params, dict) else {},
+                }
+            )
+            logger.debug(
+                "Heuristic bypass: Detected bullet-JSON tool call '{}'", tool_name
+            )
+            remaining = remaining[: match.start()] + remaining[match.end() :]
+
+        if not detected_tools:
+            return self._buffer, []
+
+        return remaining, detected_tools
 
     def _extract_web_tool_json_calls(self) -> tuple[str, list[dict[str, Any]]]:
         detected_tools: list[dict[str, Any]] = []
@@ -97,7 +131,9 @@ class HeuristicToolParser:
         """Feed text and return safe text plus detected tool calls."""
         self._buffer += text
         self._buffer = self._strip_control_tokens(self._buffer)
-        self._buffer, detected_tools = self._extract_web_tool_json_calls()
+        self._buffer, detected_tools = self._extract_bullet_func_json_calls()
+        if not detected_tools:
+            self._buffer, detected_tools = self._extract_web_tool_json_calls()
         filtered_output_parts: list[str] = []
 
         while True:

--- a/core/anthropic/tools.py
+++ b/core/anthropic/tools.py
@@ -17,6 +17,7 @@ class ParserState(Enum):
     TEXT = 1
     MATCHING_FUNCTION = 2
     PARSING_PARAMETERS = 3
+    BUFFERING_JSON = 4  # accumulating bare {...} potential tool call
 
 
 class HeuristicToolParser:
@@ -49,6 +50,9 @@ class HeuristicToolParser:
         self._current_tool_id = None
         self._current_function_name = None
         self._current_parameters = {}
+        self._json_depth = 0       # brace depth while BUFFERING_JSON
+        self._json_in_string = False  # inside a JSON string literal
+        self._json_escape = False  # previous char was backslash
 
     @staticmethod
     def _parse_tool_call_json(raw: str) -> dict[str, Any] | None:
@@ -219,6 +223,17 @@ class HeuristicToolParser:
                     filtered_output_parts.append(self._buffer[:idx])
                     self._buffer = self._buffer[idx:]
                     self._state = ParserState.MATCHING_FUNCTION
+                elif "{" in self._buffer:
+                    # Potential bare-JSON tool call (no ● prefix, e.g. NIM/llama models).
+                    # Hold everything from { onward; flush only the safe prefix before it.
+                    idx = self._buffer.index("{")
+                    if idx:
+                        filtered_output_parts.append(self._buffer[:idx])
+                        self._buffer = self._buffer[idx:]
+                    self._state = ParserState.BUFFERING_JSON
+                    self._json_depth = 0
+                    self._json_in_string = False
+                    self._json_escape = False
                 else:
                     safe_prefix = self._split_incomplete_control_token_tail()
                     if safe_prefix:
@@ -228,6 +243,50 @@ class HeuristicToolParser:
                     filtered_output_parts.append(self._buffer)
                     self._buffer = ""
                     break
+
+            if self._state == ParserState.BUFFERING_JSON:
+                # Walk characters tracking depth / string state.
+                end_idx = None
+                for i, ch in enumerate(self._buffer):
+                    if self._json_escape:
+                        self._json_escape = False
+                        continue
+                    if ch == "\\" and self._json_in_string:
+                        self._json_escape = True
+                        continue
+                    if ch == '"':
+                        self._json_in_string = not self._json_in_string
+                        continue
+                    if self._json_in_string:
+                        continue
+                    if ch == "{":
+                        self._json_depth += 1
+                    elif ch == "}":
+                        self._json_depth -= 1
+                        if self._json_depth == 0:
+                            end_idx = i + 1
+                            break
+                if end_idx is None:
+                    break  # JSON incomplete — wait for more chunks
+                raw_json = self._buffer[:end_idx]
+                self._buffer = self._buffer[end_idx:]
+                self._state = ParserState.TEXT
+                parsed = self._parse_tool_call_json(raw_json)
+                if parsed:
+                    detected_tools.append(
+                        {
+                            "type": "tool_use",
+                            "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
+                            **parsed,
+                        }
+                    )
+                    logger.debug(
+                        "Heuristic bypass: Detected bare-JSON tool call '{}'",
+                        parsed["name"],
+                    )
+                else:
+                    # Not a tool call — emit as text and keep going
+                    filtered_output_parts.append(raw_json)
 
             if self._state == ParserState.MATCHING_FUNCTION:
                 match = self._FUNC_START_PATTERN.search(self._buffer)
@@ -297,11 +356,37 @@ class HeuristicToolParser:
 
         return "".join(filtered_output_parts), detected_tools
 
-    def flush(self) -> list[dict[str, Any]]:
-        """Flush any remaining tool call in the buffer."""
+    def flush_all(self) -> tuple[str, list[dict[str, Any]]]:
+        """Flush any remaining buffered content.
+
+        Returns (remaining_text, tool_calls). remaining_text is non-empty only
+        when BUFFERING_JSON held back content that turned out not to be a tool call.
+        """
         self._buffer = self._strip_control_tokens(self._buffer)
-        detected_tools = []
-        if self._state == ParserState.PARSING_PARAMETERS:
+        detected_tools: list[dict[str, Any]] = []
+        remaining_text = ""
+
+        if self._state == ParserState.BUFFERING_JSON:
+            # Stream ended while we were holding back a potential JSON blob.
+            # Try to parse it as a tool call one final time.
+            parsed = self._parse_tool_call_json(self._buffer)
+            if parsed:
+                detected_tools.append(
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
+                        **parsed,
+                    }
+                )
+                logger.debug(
+                    "Heuristic bypass: Flushed bare-JSON tool call '{}'", parsed["name"]
+                )
+            else:
+                remaining_text = self._buffer
+            self._state = ParserState.TEXT
+            self._buffer = ""
+
+        elif self._state == ParserState.PARSING_PARAMETERS:
             partial_matches = re.finditer(
                 r"<parameter=([^>]+)>(.*)$", self._buffer, re.DOTALL
             )
@@ -321,4 +406,9 @@ class HeuristicToolParser:
             self._state = ParserState.TEXT
             self._buffer = ""
 
-        return detected_tools
+        return remaining_text, detected_tools
+
+    def flush(self) -> list[dict[str, Any]]:
+        """Backwards-compatible flush — returns only tool calls, discards held text."""
+        _, tools = self.flush_all()
+        return tools

--- a/core/anthropic/tools.py
+++ b/core/anthropic/tools.py
@@ -35,10 +35,12 @@ class HeuristicToolParser:
     _WEB_TOOL_JSON_PATTERN = re.compile(
         r"(?is)\b(?:use\s+)?(?P<tool>WebFetch|WebSearch)\b.*?(?P<json>\{.*?\})"
     )
-    # Matches: ● {"type": "function", "name": "Foo", "parameters": {...}}
-    # emitted by some OpenAI-compat models (e.g. llama-4-maverick via NIM)
-    _BULLET_FUNC_JSON_PATTERN = re.compile(
-        r"●\s*(\{[^{}]*\"type\"\s*:\s*\"function\"[^{}]*\"name\"\s*:\s*\"(?P<name>[^\"]+)\"[^{}]*\"parameters\"\s*:\s*(?P<params>\{[^{}]*\})[^{}]*\})"
+    # Matches ● {...} where JSON has a "name" key and "arguments" or "parameters" key.
+    # Covers llama-4-maverick (parameters), OpenAI-compat (arguments), any field order.
+    _BULLET_JSON_PREFIX = re.compile(r"●\s*(\{)", re.DOTALL)
+    # Matches <tool_call>...</tool_call> XML wrapper used by Llama 3.1+, Qwen, Mistral.
+    _TOOL_CALL_XML_PATTERN = re.compile(
+        r"<tool_call>\s*(?P<json>\{.*?\})\s*</tool_call>", re.DOTALL
     )
 
     def __init__(self):
@@ -48,33 +50,107 @@ class HeuristicToolParser:
         self._current_function_name = None
         self._current_parameters = {}
 
-    def _extract_bullet_func_json_calls(self) -> tuple[str, list[dict[str, Any]]]:
-        """Detect ● {"type": "function", "name": "...", "parameters": {...}} style."""
-        detected_tools: list[dict[str, Any]] = []
-        remaining = self._buffer
+    @staticmethod
+    def _parse_tool_call_json(raw: str) -> dict[str, Any] | None:
+        """
+        Parse a JSON blob that may represent a tool call in any of these shapes:
+          {"name": "X", "arguments": {...}}        — OpenAI / most NIM models
+          {"name": "X", "parameters": {...}}       — llama-4-maverick via NIM
+          {"type": "function", "name": "X", ...}  — verbose OpenAI variant
+          {"function": {"name": "X", ...}}         — nested OpenAI delta form
+        Returns {"name": str, "input": dict} or None if not a tool call.
+        """
+        try:
+            obj = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(obj, dict):
+            return None
 
-        for match in self._BULLET_FUNC_JSON_PATTERN.finditer(self._buffer):
+        # Unwrap nested {"function": {...}} form
+        if "function" in obj and isinstance(obj["function"], dict):
+            obj = obj["function"]
+
+        name = obj.get("name") or obj.get("function_name")
+        if not name or not isinstance(name, str):
+            return None
+
+        params = obj.get("arguments") or obj.get("parameters") or obj.get("inputs") or {}
+        if isinstance(params, str):
             try:
-                params = json.loads(match.group("params"))
+                params = json.loads(params)
             except json.JSONDecodeError:
                 params = {}
-            tool_name = match.group("name")
-            detected_tools.append(
-                {
-                    "type": "tool_use",
-                    "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
-                    "name": tool_name,
-                    "input": params if isinstance(params, dict) else {},
-                }
-            )
-            logger.debug(
-                "Heuristic bypass: Detected bullet-JSON tool call '{}'", tool_name
-            )
-            remaining = remaining[: match.start()] + remaining[match.end() :]
+        if not isinstance(params, dict):
+            params = {}
+
+        return {"name": name, "input": params}
+
+    def _extract_open_model_tool_calls(self) -> tuple[str, list[dict[str, Any]]]:
+        """
+        Detect tool calls emitted as text by open/NIM models:
+          1. ● {...}  — bullet-prefixed JSON (llama-4-maverick, some NIM models)
+          2. <tool_call>...</tool_call>  — XML wrapper (Llama 3.1+, Qwen, Mistral)
+        """
+        detected_tools: list[dict[str, Any]] = []
+        spans_to_remove: list[tuple[int, int]] = []
+
+        # --- XML wrapper form ---
+        for match in self._TOOL_CALL_XML_PATTERN.finditer(self._buffer):
+            parsed = self._parse_tool_call_json(match.group("json"))
+            if parsed:
+                detected_tools.append(
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
+                        **parsed,
+                    }
+                )
+                spans_to_remove.append((match.start(), match.end()))
+                logger.debug(
+                    "Heuristic bypass: Detected <tool_call> XML tool call '{}'",
+                    parsed["name"],
+                )
+
+        # --- Bullet-prefixed JSON form ---
+        for match in self._BULLET_JSON_PREFIX.finditer(self._buffer):
+            # Walk forward to find the matching closing brace
+            start = match.start()
+            brace_start = match.start(1)
+            depth = 0
+            end = None
+            for i, ch in enumerate(self._buffer[brace_start:], brace_start):
+                if ch == "{":
+                    depth += 1
+                elif ch == "}":
+                    depth -= 1
+                    if depth == 0:
+                        end = i + 1
+                        break
+            if end is None:
+                continue  # JSON not complete yet — wait for more chunks
+            raw_json = self._buffer[brace_start:end]
+            parsed = self._parse_tool_call_json(raw_json)
+            if parsed:
+                detected_tools.append(
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
+                        **parsed,
+                    }
+                )
+                spans_to_remove.append((start, end))
+                logger.debug(
+                    "Heuristic bypass: Detected ●-JSON tool call '{}'", parsed["name"]
+                )
 
         if not detected_tools:
             return self._buffer, []
 
+        # Remove matched spans in reverse order to preserve offsets
+        remaining = self._buffer
+        for s, e in sorted(spans_to_remove, reverse=True):
+            remaining = remaining[:s] + remaining[e:]
         return remaining, detected_tools
 
     def _extract_web_tool_json_calls(self) -> tuple[str, list[dict[str, Any]]]:
@@ -131,7 +207,7 @@ class HeuristicToolParser:
         """Feed text and return safe text plus detected tool calls."""
         self._buffer += text
         self._buffer = self._strip_control_tokens(self._buffer)
-        self._buffer, detected_tools = self._extract_bullet_func_json_calls()
+        self._buffer, detected_tools = self._extract_open_model_tool_calls()
         if not detected_tools:
             self._buffer, detected_tools = self._extract_web_tool_json_calls()
         filtered_output_parts: list[str] = []

--- a/core/anthropic/tools.py
+++ b/core/anthropic/tools.py
@@ -210,9 +210,14 @@ class HeuristicToolParser:
     def feed(self, text: str) -> tuple[str, list[dict[str, Any]]]:
         """Feed text and return safe text plus detected tool calls."""
         self._buffer += text
-        self._buffer = self._strip_control_tokens(self._buffer)
-        self._buffer, detected_tools = self._extract_open_model_tool_calls()
-        if not detected_tools:
+        if _CONTROL_TOKEN_START in self._buffer:
+            self._buffer = self._strip_control_tokens(self._buffer)
+        detected_tools: list[dict[str, Any]] = []
+        if "<tool_call" in self._buffer or "●" in self._buffer:
+            self._buffer, detected_tools = self._extract_open_model_tool_calls()
+        if not detected_tools and (
+            "WebFetch" in self._buffer or "WebSearch" in self._buffer
+        ):
             self._buffer, detected_tools = self._extract_web_tool_json_calls()
         filtered_output_parts: list[str] = []
 

--- a/core/anthropic/tools.py
+++ b/core/anthropic/tools.py
@@ -43,6 +43,16 @@ class HeuristicToolParser:
     _TOOL_CALL_XML_PATTERN = re.compile(
         r"<tool_call>\s*(?P<json>\{.*?\})\s*</tool_call>", re.DOTALL
     )
+    # Matches <function=NAME>...<parameter=K>V</parameter>...</function> emitted by
+    # nemotron-super and similar models *without* the leading ● bullet (NIM under
+    # heavy tool-loaded sessions sometimes drops the bullet, so the bullet-only
+    # streaming parser below misses these blocks and they leak as raw XML text).
+    _FUNCTION_BLOCK_PATTERN = re.compile(
+        r"<function=(?P<name>[^>\s]+)>(?P<body>.*?)</function>", re.DOTALL
+    )
+    _PARAM_BLOCK_PATTERN = re.compile(
+        r"<parameter=(?P<key>[^>\s]+)>(?P<val>.*?)</parameter>", re.DOTALL
+    )
 
     def __init__(self):
         self._state = ParserState.TEXT
@@ -98,6 +108,38 @@ class HeuristicToolParser:
         """
         detected_tools: list[dict[str, Any]] = []
         spans_to_remove: list[tuple[int, int]] = []
+
+        # --- <function=NAME>...</function> block form (no bullet prefix) ---
+        for match in self._FUNCTION_BLOCK_PATTERN.finditer(self._buffer):
+            name = match.group("name").strip()
+            params: dict[str, Any] = {}
+            for pm in self._PARAM_BLOCK_PATTERN.finditer(match.group("body")):
+                key = pm.group("key").strip()
+                val = pm.group("val").strip()
+                # Try to recover JSON values; fall back to raw string.
+                try:
+                    if (val.startswith("{") and val.endswith("}")) or (
+                        val.startswith("[") and val.endswith("]")
+                    ):
+                        params[key] = json.loads(val)
+                        continue
+                except json.JSONDecodeError:
+                    pass
+                params[key] = val
+            detected_tools.append(
+                {
+                    "type": "tool_use",
+                    "id": f"toolu_heuristic_{uuid.uuid4().hex[:8]}",
+                    "name": name,
+                    "input": params,
+                }
+            )
+            spans_to_remove.append((match.start(), match.end()))
+            logger.debug(
+                "Heuristic bypass: Detected <function=> XML tool call '{}' ({} params)",
+                name,
+                len(params),
+            )
 
         # --- XML wrapper form ---
         for match in self._TOOL_CALL_XML_PATTERN.finditer(self._buffer):
@@ -213,7 +255,11 @@ class HeuristicToolParser:
         if _CONTROL_TOKEN_START in self._buffer:
             self._buffer = self._strip_control_tokens(self._buffer)
         detected_tools: list[dict[str, Any]] = []
-        if "<tool_call" in self._buffer or "●" in self._buffer:
+        if (
+            "<tool_call" in self._buffer
+            or "<function=" in self._buffer
+            or "●" in self._buffer
+        ):
             self._buffer, detected_tools = self._extract_open_model_tool_calls()
         if not detected_tools and (
             "WebFetch" in self._buffer or "WebSearch" in self._buffer

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -1,0 +1,63 @@
+"""Simple context management - trim messages to configured limits."""
+
+from config.settings import Settings
+from core.anthropic.tokens import get_token_count
+
+
+class ContextManager:
+    """Manages conversation context with simple trimming."""
+
+    def __init__(self, max_messages: int | None = None, max_tokens: int | None = None):
+        """
+        Initialize context manager.
+
+        Args:
+            max_messages: Maximum number of messages to keep (None = unlimited)
+            max_tokens: Maximum token budget (None = unlimited)
+        """
+        self.max_messages = max_messages
+        self.max_tokens = max_tokens
+
+    def trim_messages(
+        self, messages: list, system: str | list | None = None
+    ) -> tuple[list, bool]:
+        """
+        Trim messages to fit within configured limits.
+
+        Args:
+            messages: List of message dicts
+            system: Optional system prompt
+
+        Returns:
+            (trimmed_messages, was_trimmed)
+        """
+        original_count = len(messages)
+        trimmed = messages
+
+        # Apply message count limit
+        if self.max_messages and self.max_messages > 0:
+            if len(trimmed) > self.max_messages:
+                # Keep first few + last messages to maintain conversation flow
+                keep_start = max(2, self.max_messages // 5)
+                keep_end = self.max_messages - keep_start
+
+                trimmed = trimmed[:keep_start] + trimmed[-keep_end:]
+
+        # Apply token limit if set
+        if self.max_tokens and self.max_tokens > 0:
+            tokens = get_token_count(trimmed, system)
+            if tokens > self.max_tokens:
+                # Reduce by removing oldest message pairs
+                while len(trimmed) > 4 and tokens > self.max_tokens * 0.9:
+                    trimmed = trimmed[2:]  # Remove oldest user/assistant pair
+                    tokens = get_token_count(trimmed, system)
+
+        return trimmed, len(trimmed) < original_count
+
+
+def get_context_manager(settings: Settings) -> ContextManager:
+    """Create a ContextManager from settings."""
+    return ContextManager(
+        max_messages=settings.max_messages if settings.max_messages > 0 else None,
+        max_tokens=settings.context_max_tokens if settings.context_max_tokens > 0 else None,
+    )

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -53,16 +53,24 @@ def _sanitize_seam(messages: list) -> list:
 class ContextManager:
     """Manages conversation context with simple trimming."""
 
-    def __init__(self, max_messages: int | None = None, max_tokens: int | None = None):
+    def __init__(
+        self,
+        max_messages: int | None = None,
+        max_tokens: int | None = None,
+        min_messages: int = 20,
+    ):
         """
         Initialize context manager.
 
         Args:
             max_messages: Maximum number of messages to keep (None = unlimited)
             max_tokens: Maximum token budget (None = unlimited)
+            min_messages: Minimum messages to keep after trimming (prevents
+                losing all context when thinking blocks inflate token counts)
         """
         self.max_messages = max_messages
         self.max_tokens = max_tokens
+        self.min_messages = min_messages
 
     def trim_messages(
         self, messages: list, system: str | list | None = None, tools: list | None = None
@@ -73,6 +81,7 @@ class ContextManager:
         Args:
             messages: List of message dicts
             system: Optional system prompt
+            tools: Optional list of tool definitions
 
         Returns:
             (trimmed_messages, was_trimmed)
@@ -93,8 +102,11 @@ class ContextManager:
         if self.max_tokens and self.max_tokens > 0:
             tokens = get_token_count(trimmed, system, tools)
             if tokens > self.max_tokens:
-                # Reduce by removing oldest message pairs
-                while len(trimmed) > 4 and tokens > self.max_tokens * 0.9:
+                # Reduce by removing oldest message pairs, but never drop below
+                # min_messages — thinking blocks can inflate counts dramatically
+                # and stripping everything leaves the model with no context.
+                floor = max(4, self.min_messages)
+                while len(trimmed) > floor and tokens > self.max_tokens * 0.9:
                     trimmed = trimmed[2:]  # Remove oldest user/assistant pair
                     tokens = get_token_count(trimmed, system, tools)
 
@@ -111,4 +123,5 @@ def get_context_manager(settings: Settings) -> ContextManager:
     return ContextManager(
         max_messages=settings.max_messages if settings.max_messages > 0 else None,
         max_tokens=settings.context_max_tokens if settings.context_max_tokens > 0 else None,
+        min_messages=settings.context_min_messages,
     )

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -4,6 +4,52 @@ from config.settings import Settings
 from core.anthropic.tokens import get_token_count
 
 
+def _has_tool_use(message: object) -> bool:
+    """Return True if an assistant message contains any tool_use blocks."""
+    content = getattr(message, "content", None)
+    if not isinstance(content, list):
+        return False
+    return any(
+        (getattr(b, "type", None) or (b if not hasattr(b, "type") else None)) == "tool_use"
+        or (isinstance(b, dict) and b.get("type") == "tool_use")
+        for b in content
+    )
+
+
+def _has_tool_result(message: object) -> bool:
+    """Return True if a user message contains any tool_result blocks."""
+    content = getattr(message, "content", None)
+    if not isinstance(content, list):
+        return False
+    return any(
+        (getattr(b, "type", None) or (b if not hasattr(b, "type") else None)) == "tool_result"
+        or (isinstance(b, dict) and b.get("type") == "tool_result")
+        for b in content
+    )
+
+
+def _sanitize_seam(messages: list) -> list:
+    """Drop leading messages until the conversation starts at a clean boundary.
+
+    After trimming, the head of the list may be an assistant message whose
+    tool_use blocks have no matching tool_result in the following user message
+    (the result was in a removed section), or a user message that consists
+    entirely of orphaned tool_results.  Either triggers a 400 from NIM/OpenAI.
+
+    Strategy: drop from the front until:
+    1. The first message is a user message.
+    2. That user message does not consist solely of tool_result blocks
+       (i.e., it is a genuine human turn, not a dangling tool response).
+    """
+    while messages:
+        first = messages[0]
+        role = getattr(first, "role", None) or (first.get("role") if isinstance(first, dict) else None)
+        if role == "user" and not _has_tool_result(first):
+            break
+        messages = messages[1:]
+    return messages
+
+
 class ContextManager:
     """Manages conversation context with simple trimming."""
 
@@ -51,6 +97,11 @@ class ContextManager:
                 while len(trimmed) > 4 and tokens > self.max_tokens * 0.9:
                     trimmed = trimmed[2:]  # Remove oldest user/assistant pair
                     tokens = get_token_count(trimmed, system, tools)
+
+        # Sanitize the head of the trimmed list: drop any leading messages that
+        # would form an invalid conversation structure (orphaned tool_use /
+        # tool_result at the cut boundary), which causes a 400 from providers.
+        trimmed = _sanitize_seam(list(trimmed))
 
         return trimmed, len(trimmed) < original_count
 

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -19,7 +19,7 @@ class ContextManager:
         self.max_tokens = max_tokens
 
     def trim_messages(
-        self, messages: list, system: str | list | None = None
+        self, messages: list, system: str | list | None = None, tools: list | None = None
     ) -> tuple[list, bool]:
         """
         Trim messages to fit within configured limits.
@@ -45,12 +45,12 @@ class ContextManager:
 
         # Apply token limit if set
         if self.max_tokens and self.max_tokens > 0:
-            tokens = get_token_count(trimmed, system)
+            tokens = get_token_count(trimmed, system, tools)
             if tokens > self.max_tokens:
                 # Reduce by removing oldest message pairs
                 while len(trimmed) > 4 and tokens > self.max_tokens * 0.9:
                     trimmed = trimmed[2:]  # Remove oldest user/assistant pair
-                    tokens = get_token_count(trimmed, system)
+                    tokens = get_token_count(trimmed, system, tools)
 
         return trimmed, len(trimmed) < original_count
 

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -16,6 +16,10 @@ def _has_tool_use(message: object) -> bool:
     )
 
 
+def _role(message: object) -> str | None:
+    return getattr(message, "role", None) or (message.get("role") if isinstance(message, dict) else None)
+
+
 def _has_tool_result(message: object) -> bool:
     """Return True if a user message contains any tool_result blocks."""
     content = getattr(message, "content", None)
@@ -96,7 +100,18 @@ class ContextManager:
                 keep_start = max(2, self.max_messages // 5)
                 keep_end = self.max_messages - keep_start
 
-                trimmed = trimmed[:keep_start] + trimmed[-keep_end:]
+                first_chunk = list(trimmed[:keep_start])
+                # Sanitize last_chunk so it starts at a clean user boundary —
+                # prevents consecutive assistant+assistant at the seam and
+                # orphaned tool_result blocks at the head of the tail.
+                last_chunk = _sanitize_seam(list(trimmed[-keep_end:]))
+
+                # Drop trailing assistant+tool_use from first_chunk whose
+                # tool_result landed in the removed middle section.
+                while first_chunk and _role(first_chunk[-1]) == "assistant" and _has_tool_use(first_chunk[-1]):
+                    first_chunk.pop()
+
+                trimmed = first_chunk + last_chunk
 
         # Apply token limit if set
         if self.max_tokens and self.max_tokens > 0:

--- a/core/context_manager.py
+++ b/core/context_manager.py
@@ -32,7 +32,7 @@ def _has_tool_result(message: object) -> bool:
     )
 
 
-def _sanitize_seam(messages: list) -> list:
+def _sanitize_seam(messages: list, max_drops: int | None = None) -> list:
     """Drop leading messages until the conversation starts at a clean boundary.
 
     After trimming, the head of the list may be an assistant message whose
@@ -44,13 +44,22 @@ def _sanitize_seam(messages: list) -> list:
     1. The first message is a user message.
     2. That user message does not consist solely of tool_result blocks
        (i.e., it is a genuine human turn, not a dangling tool response).
+
+    If ``max_drops`` is set, stop after that many drops even if the head is
+    still invalid.  Used as a safety net so the seam walker cannot wipe the
+    entire conversation when every user turn is a tool_result (Claude Code's
+    normal working pattern).
     """
+    dropped = 0
     while messages:
+        if max_drops is not None and dropped >= max_drops:
+            break
         first = messages[0]
         role = getattr(first, "role", None) or (first.get("role") if isinstance(first, dict) else None)
         if role == "user" and not _has_tool_result(first):
             break
         messages = messages[1:]
+        dropped += 1
     return messages
 
 
@@ -128,15 +137,52 @@ class ContextManager:
         # Sanitize the head of the trimmed list: drop any leading messages that
         # would form an invalid conversation structure (orphaned tool_use /
         # tool_result at the cut boundary), which causes a 400 from providers.
-        trimmed = _sanitize_seam(list(trimmed))
+        # If unbounded sanitization would drop us below the configured floor —
+        # which happens routinely in Claude Code where every user turn is a
+        # tool_result — fall back to a bounded version that preserves context.
+        sanitized = _sanitize_seam(list(trimmed))
+        floor = max(4, self.min_messages) if (self.max_tokens or self.max_messages) else 0
+        if floor > 0 and len(sanitized) < floor and len(trimmed) >= floor:
+            sanitized = _sanitize_seam(list(trimmed), max_drops=4)
+        trimmed = sanitized
 
         return trimmed, len(trimmed) < original_count
 
 
-def get_context_manager(settings: Settings) -> ContextManager:
-    """Create a ContextManager from settings."""
+def get_context_manager(
+    settings: Settings, provider_id: str | None = None
+) -> ContextManager:
+    """Create a ContextManager from settings, optionally provider-scoped.
+
+    Per-provider overrides (NIM_*/OPENROUTER_*) win when set (>0); otherwise
+    the global MAX_MESSAGES / CONTEXT_MAX_TOKENS / CONTEXT_MIN_MESSAGES apply.
+    Lets you size context budgets independently for each upstream — e.g.
+    keep NIM tight (256k cap, free tier latency) while letting OR Qwen run
+    near 1M context where the model supports it.
+    """
+    max_messages = settings.max_messages
+    max_tokens = settings.context_max_tokens
+    min_messages = settings.context_min_messages
+
+    if provider_id == "nvidia_nim":
+        max_messages = getattr(settings, "nim_max_messages", 0) or max_messages
+        max_tokens = getattr(settings, "nim_context_max_tokens", 0) or max_tokens
+        min_messages = (
+            getattr(settings, "nim_context_min_messages", 0) or min_messages
+        )
+    elif provider_id == "open_router":
+        max_messages = (
+            getattr(settings, "openrouter_max_messages", 0) or max_messages
+        )
+        max_tokens = (
+            getattr(settings, "openrouter_context_max_tokens", 0) or max_tokens
+        )
+        min_messages = (
+            getattr(settings, "openrouter_context_min_messages", 0) or min_messages
+        )
+
     return ContextManager(
-        max_messages=settings.max_messages if settings.max_messages > 0 else None,
-        max_tokens=settings.context_max_tokens if settings.context_max_tokens > 0 else None,
-        min_messages=settings.context_min_messages,
+        max_messages=max_messages if max_messages > 0 else None,
+        max_tokens=max_tokens if max_tokens > 0 else None,
+        min_messages=min_messages,
     )

--- a/crear_acceso_directo.ps1
+++ b/crear_acceso_directo.ps1
@@ -1,0 +1,18 @@
+$WshShell = New-Object -comObject WScript.Shell
+$Desktop = [System.Environment]::GetFolderPath("Desktop")
+
+# Intentar escritorio de OneDrive si existe
+$OneDriveDesktop = "$env:USERPROFILE\OneDrive\Desktop"
+if (Test-Path $OneDriveDesktop) {
+    $Desktop = $OneDriveDesktop
+}
+
+$Shortcut = $WshShell.CreateShortcut("$Desktop\Claude Code Gratis.lnk")
+$Shortcut.TargetPath = "C:\Users\titan\free-claude-code\INICIAR_CLAUDE_GRATIS.bat"
+$Shortcut.WorkingDirectory = "C:\Users\titan\free-claude-code"
+$Shortcut.IconLocation = "C:\Windows\System32\cmd.exe,0"
+$Shortcut.Description = "Claude Code gratis via NVIDIA NIM Proxy"
+$Shortcut.WindowStyle = 1
+$Shortcut.Save()
+
+Write-Host "Acceso directo creado en: $Desktop\Claude Code Gratis.lnk" -ForegroundColor Green

--- a/messaging/rendering/telegram_markdown.py
+++ b/messaging/rendering/telegram_markdown.py
@@ -110,10 +110,11 @@ def render_markdown_to_mdv2(text: str) -> str:
                 while i < len(children) and children[i].type != "link_close":
                     inner_tokens.append(children[i])
                     i += 1
-                link_text = ""
-                for child in inner_tokens:
-                    if child.type == "text" or child.type == "code_inline":
-                        link_text += child.content
+                link_text = "".join(
+                    child.content
+                    for child in inner_tokens
+                    if child.type in {"text", "code_inline"}
+                )
                 out.append(
                     f"[{escape_md_v2(link_text)}]({escape_md_v2_link_url(href)})"
                 )

--- a/providers/common/message_converter.py
+++ b/providers/common/message_converter.py
@@ -1,0 +1,234 @@
+"""Message and tool format converters."""
+
+import json
+from typing import Any
+
+
+def get_block_attr(block: Any, attr: str, default: Any = None) -> Any:
+    """Get attribute from object or dict."""
+    if hasattr(block, attr):
+        return getattr(block, attr)
+    if isinstance(block, dict):
+        return block.get(attr, default)
+    return default
+
+
+def get_block_type(block: Any) -> str | None:
+    """Get block type from object or dict."""
+    return get_block_attr(block, "type")
+
+
+class AnthropicToOpenAIConverter:
+    """Converts Anthropic message format to OpenAI format."""
+
+    @staticmethod
+    def convert_messages(
+        messages: list[Any],
+        *,
+        include_reasoning_for_openrouter: bool = False,
+        parallel_tool_calls: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Convert a list of Anthropic messages to OpenAI format.
+
+        When include_reasoning_for_openrouter is True, assistant messages with
+        thinking blocks get reasoning_content added for OpenRouter multi-turn
+        reasoning continuation.
+        """
+        result = []
+
+        for msg in messages:
+            role = msg.role
+            content = msg.content
+
+            if isinstance(content, str):
+                result.append({"role": role, "content": content})
+            elif isinstance(content, list):
+                if role == "assistant":
+                    result.extend(
+                        AnthropicToOpenAIConverter._convert_assistant_message(
+                            content,
+                            include_reasoning_for_openrouter=include_reasoning_for_openrouter,
+                            parallel_tool_calls=parallel_tool_calls,
+                        )
+                    )
+                elif role == "user":
+                    result.extend(
+                        AnthropicToOpenAIConverter._convert_user_message(content)
+                    )
+            else:
+                result.append({"role": role, "content": str(content)})
+
+        return result
+
+    @staticmethod
+    def _convert_assistant_message(
+        content: list[Any],
+        *,
+        include_reasoning_for_openrouter: bool = False,
+        parallel_tool_calls: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Convert assistant message blocks, preserving interleaved thinking+text order."""
+        content_parts: list[str] = []
+        thinking_parts: list[str] = []
+        tool_calls: list[dict[str, Any]] = []
+
+        for block in content:
+            block_type = get_block_type(block)
+
+            if block_type == "text":
+                content_parts.append(get_block_attr(block, "text", ""))
+            elif block_type == "thinking":
+                thinking = get_block_attr(block, "thinking", "")
+                content_parts.append(f"<think>\n{thinking}\n</think>")
+                if include_reasoning_for_openrouter:
+                    thinking_parts.append(thinking)
+            elif block_type == "tool_use":
+                tool_input = get_block_attr(block, "input", {})
+                tool_calls.append(
+                    {
+                        "id": get_block_attr(block, "id"),
+                        "type": "function",
+                        "function": {
+                            "name": get_block_attr(block, "name"),
+                            "arguments": json.dumps(tool_input)
+                            if isinstance(tool_input, dict)
+                            else str(tool_input),
+                        },
+                    }
+                )
+
+        content_str = "\n\n".join(content_parts)
+
+        # Ensure content is never an empty string for assistant messages
+        # NIM (especially Mistral models) requires non-empty content if there are no tool calls
+        if not content_str and not tool_calls:
+            content_str = " "
+
+        msg: dict[str, Any] = {
+            "role": "assistant",
+            "content": content_str,
+        }
+        if tool_calls:
+            if not parallel_tool_calls:
+                msg["tool_calls"] = tool_calls[:1]
+            else:
+                msg["tool_calls"] = tool_calls
+        if include_reasoning_for_openrouter and thinking_parts:
+            msg["reasoning_content"] = "\n".join(thinking_parts)
+
+        return [msg]
+
+    @staticmethod
+    def _convert_user_message(content: list[Any]) -> list[dict[str, Any]]:
+        """Convert user message blocks (including tool results), preserving order."""
+        result: list[dict[str, Any]] = []
+        text_parts: list[str] = []
+
+        def flush_text() -> None:
+            if text_parts:
+                result.append({"role": "user", "content": "\n".join(text_parts)})
+                text_parts.clear()
+
+        for block in content:
+            block_type = get_block_type(block)
+
+            if block_type == "text":
+                text_parts.append(get_block_attr(block, "text", ""))
+            elif block_type == "tool_result":
+                flush_text()
+                tool_content = get_block_attr(block, "content", "")
+                if isinstance(tool_content, list):
+                    tool_content = "\n".join(
+                        item.get("text", str(item))
+                        if isinstance(item, dict)
+                        else str(item)
+                        for item in tool_content
+                    )
+                result.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": get_block_attr(block, "tool_use_id"),
+                        "content": str(tool_content) if tool_content else "",
+                    }
+                )
+
+        flush_text()
+        return result
+
+    @staticmethod
+    def convert_tools(tools: list[Any]) -> list[dict[str, Any]]:
+        """Convert Anthropic tools to OpenAI format."""
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description or "",
+                    "parameters": tool.input_schema,
+                },
+            }
+            for tool in tools
+        ]
+
+    @staticmethod
+    def convert_system_prompt(system: Any) -> dict[str, str] | None:
+        """Convert Anthropic system prompt to OpenAI format."""
+        if isinstance(system, str):
+            return {"role": "system", "content": system}
+        elif isinstance(system, list):
+            text_parts = [
+                get_block_attr(block, "text", "")
+                for block in system
+                if get_block_type(block) == "text"
+            ]
+            if text_parts:
+                return {"role": "system", "content": "\n\n".join(text_parts).strip()}
+        return None
+
+
+def build_base_request_body(
+    request_data: Any,
+    *,
+    default_max_tokens: int | None = None,
+    include_reasoning_for_openrouter: bool = False,
+    parallel_tool_calls: bool = True,
+) -> dict[str, Any]:
+    """Build the common parts of an OpenAI-format request body.
+
+    Handles message conversion, system prompt, max_tokens, temperature,
+    top_p, stop sequences, tools, and tool_choice. Provider-specific
+    parameters (extra_body, penalties, NIM settings) are added by callers.
+    """
+    from providers.common.utils import set_if_not_none
+
+    messages = AnthropicToOpenAIConverter.convert_messages(
+        request_data.messages,
+        include_reasoning_for_openrouter=include_reasoning_for_openrouter,
+        parallel_tool_calls=getattr(request_data, "parallel_tool_calls", True),
+    )
+
+    system = getattr(request_data, "system", None)
+    if system:
+        system_msg = AnthropicToOpenAIConverter.convert_system_prompt(system)
+        if system_msg:
+            messages.insert(0, system_msg)
+
+    body: dict[str, Any] = {"model": request_data.model, "messages": messages}
+
+    max_tokens = getattr(request_data, "max_tokens", None)
+    set_if_not_none(body, "max_tokens", max_tokens or default_max_tokens)
+    set_if_not_none(body, "temperature", getattr(request_data, "temperature", None))
+    set_if_not_none(body, "top_p", getattr(request_data, "top_p", None))
+
+    stop_sequences = getattr(request_data, "stop_sequences", None)
+    if stop_sequences:
+        body["stop"] = stop_sequences
+
+    tools = getattr(request_data, "tools", None)
+    if tools:
+        body["tools"] = AnthropicToOpenAIConverter.convert_tools(tools)
+    tool_choice = getattr(request_data, "tool_choice", None)
+    if tool_choice:
+        body["tool_choice"] = tool_choice
+
+    return body

--- a/providers/model_listing.py
+++ b/providers/model_listing.py
@@ -61,7 +61,22 @@ def extract_openrouter_tool_model_ids(
 def extract_openrouter_tool_model_infos(
     payload: Any, *, provider_name: str
 ) -> frozenset[ProviderModelInfo]:
-    """Extract OpenRouter tool-capable model ids with thinking capability metadata."""
+    """Extract OpenRouter tool-capable model ids with thinking metadata.
+
+    By default only free models are returned, to prevent unexpected paid usage
+    on accounts with credits.  Set ``OPENROUTER_INCLUDE_PAID_MODELS=true`` to
+    surface paid models in the model picker too — useful when you have OR
+    credits and want to opt into paid models from Claude Code's /model menu.
+    """
+    import os
+
+    include_paid = os.environ.get("OPENROUTER_INCLUDE_PAID_MODELS", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
     data = _field(payload, "data")
     if not _is_sequence(data):
         raise _malformed(provider_name, "expected top-level data array")
@@ -71,6 +86,8 @@ def extract_openrouter_tool_model_infos(
         model_id = _field(item, "id")
         if not isinstance(model_id, str) or not model_id.strip():
             raise _malformed(provider_name, "expected every data item to include id")
+        if not include_paid and not _is_openrouter_free_model(item, model_id):
+            continue
 
         supported_parameters = _field(item, "supported_parameters")
         if not _is_sequence(supported_parameters):
@@ -88,6 +105,25 @@ def extract_openrouter_tool_model_infos(
         )
 
     return frozenset(model_infos)
+
+
+def _is_openrouter_free_model(item: Any, model_id: str) -> bool:
+    """Return True for OpenRouter models that should not incur paid usage."""
+    if model_id.endswith(":free"):
+        return True
+    pricing = _field(item, "pricing")
+    if not isinstance(pricing, Mapping):
+        return False
+    return _is_zero_price(_field(pricing, "prompt")) and _is_zero_price(
+        _field(pricing, "completion")
+    )
+
+
+def _is_zero_price(value: Any) -> bool:
+    try:
+        return float(value) == 0.0
+    except (TypeError, ValueError):
+        return False
 
 
 def extract_ollama_model_ids(payload: Any, *, provider_name: str) -> frozenset[str]:

--- a/providers/nvidia_nim/request.py
+++ b/providers/nvidia_nim/request.py
@@ -44,10 +44,11 @@ def _clone_strip_extra_body(
 
     Returns ``None`` when there is no ``extra_body`` dict or ``strip`` reports no change.
     """
+    # Check original before cloning — avoids deepcopy when extra_body is absent.
+    if not isinstance(body.get("extra_body"), dict):
+        return None
     cloned_body = deepcopy(body)
     extra_body = cloned_body.get("extra_body")
-    if not isinstance(extra_body, dict):
-        return None
     if not strip(extra_body):
         return None
     if not extra_body:
@@ -82,6 +83,17 @@ def _strip_message_reasoning_content(body: dict[str, Any]) -> bool:
         ):
             removed = True
     return removed
+
+
+def _schema_has_booleans(value: Any) -> bool:
+    """Fast scan for boolean values in a JSON schema tree."""
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, dict):
+        return any(_schema_has_booleans(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_schema_has_booleans(item) for item in value)
+    return False
 
 
 def _sanitize_nim_schema_node(value: Any) -> tuple[bool, Any]:
@@ -129,6 +141,16 @@ def _sanitize_nim_tool_schemas(body: dict[str, Any]) -> None:
     if not isinstance(tools, list):
         return
 
+    # Fast path: Claude Code tool schemas virtually never contain booleans.
+    # Skip the full recursive walk unless a boolean is actually present.
+    if not any(
+        _schema_has_booleans(
+            tool.get("function", {}).get("parameters") if isinstance(tool, dict) else None
+        )
+        for tool in tools
+    ):
+        return
+
     sanitized_tools: list[Any] = []
     for tool in tools:
         if not isinstance(tool, dict):
@@ -172,9 +194,14 @@ def clone_body_without_chat_template(body: dict[str, Any]) -> dict[str, Any] | N
 
 def clone_body_without_reasoning_content(body: dict[str, Any]) -> dict[str, Any] | None:
     """Clone a request body and strip assistant message ``reasoning_content`` fields."""
-    cloned_body = deepcopy(body)
-    if not _strip_message_reasoning_content(cloned_body):
+    # Check original before cloning — avoids deepcopy when no reasoning_content present.
+    messages = body.get("messages")
+    if not isinstance(messages, list):
         return None
+    if not any(isinstance(m, dict) and "reasoning_content" in m for m in messages):
+        return None
+    cloned_body = deepcopy(body)
+    _strip_message_reasoning_content(cloned_body)
     return cloned_body
 
 

--- a/providers/nvidia_nim/request.py
+++ b/providers/nvidia_nim/request.py
@@ -193,6 +193,7 @@ def build_request_body(
             reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
             if thinking_enabled
             else ReasoningReplayMode.DISABLED,
+            parallel_tool_calls=nim.parallel_tool_calls,
         )
     except OpenAIConversionError as exc:
         raise InvalidRequestError(str(exc)) from exc

--- a/providers/nvidia_nim/request.py
+++ b/providers/nvidia_nim/request.py
@@ -193,7 +193,6 @@ def build_request_body(
             reasoning_replay=ReasoningReplayMode.REASONING_CONTENT
             if thinking_enabled
             else ReasoningReplayMode.DISABLED,
-            parallel_tool_calls=nim.parallel_tool_calls,
         )
     except OpenAIConversionError as exc:
         raise InvalidRequestError(str(exc)) from exc

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -77,17 +77,25 @@ class OpenAIChatTransport(BaseProvider):
             rate_window=config.rate_window,
             max_concurrency=config.max_concurrency,
         )
-        http_client = None
-        if config.proxy:
-            http_client = httpx.AsyncClient(
-                proxy=config.proxy,
-                timeout=httpx.Timeout(
-                    config.http_read_timeout,
-                    connect=config.http_connect_timeout,
-                    read=config.http_read_timeout,
-                    write=config.http_write_timeout,
-                ),
-            )
+        # Always create an explicit httpx client so we control keepalive settings.
+        # Default httpx keepalive_expiry=5s causes a fresh TCP+TLS handshake for
+        # every request when models take >5s to respond (common with 120B models).
+        # 600s keeps connections alive across the typical inter-request gap.
+        _pool_size = max(20, config.max_concurrency * 4)
+        http_client = httpx.AsyncClient(
+            proxy=config.proxy or None,
+            timeout=httpx.Timeout(
+                config.http_read_timeout,
+                connect=config.http_connect_timeout,
+                read=config.http_read_timeout,
+                write=config.http_write_timeout,
+            ),
+            limits=httpx.Limits(
+                max_connections=_pool_size,
+                max_keepalive_connections=_pool_size,
+                keepalive_expiry=600.0,
+            ),
+        )
         self._client = AsyncOpenAI(
             api_key=self._api_key,
             base_url=self._base_url,

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -383,7 +383,12 @@ class OpenAIChatTransport(BaseProvider):
                     yield event
                 yield sse.emit_text_delta(remaining.content)
 
-        for tool_use in heuristic_parser.flush():
+        flush_text, flush_tools = heuristic_parser.flush_all()
+        if flush_text:
+            for event in sse.ensure_text_block():
+                yield event
+            yield sse.emit_text_delta(flush_text)
+        for tool_use in flush_tools:
             for event in _iter_heuristic_tool_use_sse(sse, tool_use):
                 yield event
 


### PR DESCRIPTION
## Summary

### Context truncation (tool-aware, seam-safe)
- **MAX_MESSAGES** — trim conversation to last N messages before forwarding
- **CONTEXT_MAX_TOKENS** — token-budget trimming counts tool schemas (~200 tok × N tools) in the budget, not just messages
- **Seam sanitizer** — after trimming, drops leading messages until the conversation starts at a clean user turn; prevents 400 Bad Request when aggressive cuts orphan a `tool_use` block with no matching `tool_result`
- **`min_messages` floor** — prevents over-trimming to 0 messages on tool-heavy conversations
- **Bounded seam-walker fallback** *(new)* — when the unbounded walker would push results below `min_messages` (which happens routinely in Claude Code where every user turn is a tool_result), fall back to a 4-drop max bounded variant. Observed in production as `CONTEXT: trimmed 35 → 0 messages` mid-session — fix prevents catastrophic context wipeout.
- **Consecutive assistant dedup** — removes back-to-back assistant messages at the trim seam that NIM rejects

### Per-provider context budgets *(new)*
Tune NIM and OpenRouter independently:
- `NIM_CONTEXT_MAX_TOKENS`, `NIM_CONTEXT_MIN_MESSAGES`, `NIM_MAX_MESSAGES`
- `OPENROUTER_CONTEXT_MAX_TOKENS`, `OPENROUTER_CONTEXT_MIN_MESSAGES`, `OPENROUTER_MAX_MESSAGES`

Set per-provider value (>0) to override the global default for that provider only. Lets you keep NIM tight for free-tier latency (5-min stream cap, 256k context) while letting OR Qwen models use their full 1M-context window. `services.py` resolves routing before context-trim so the right provider's budget applies.

### Heuristic parser: `<function=NAME>` without leading bullet *(new)*
Some models (nemotron-super under heavy tool-loaded sessions, others) emit OpenAI-XML-style tool calls without the `●` bullet. The existing parser's `_FUNC_START_PATTERN` required the bullet, so those blocks leaked as raw XML to the client. Added `_FUNCTION_BLOCK_PATTERN` to catch the bullet-less variant in one regex; `<parameter=KEY>VAL</parameter>` extraction unchanged.

### OpenRouter improvements *(new)*
- **`OPENROUTER_INCLUDE_PAID_MODELS=true`** — opt-in to surface paid OR models in `/model` menu (default: free-only filter preserved). Lets paid Qwen models (e.g. `qwen3-235b-a22b-2507`, `qwen3-coder`, `qwen3-coder-flash`) appear after credit top-up.
- **`OPENROUTER_ENABLE_THINKING`** — provider-scoped thinking flag.
- **Auto-detect `-thinking` model variants** by name on OR routes (`qwen3-235b-a22b-thinking-2507` → reasoning mode auto-on without user config).

### Provider / model fixes
- **NIM_PARALLEL_TOOL_CALLS** — env flag to serialize tool calls for models that return 400 on parallel calls
- **Claude 4 short-form IDs** — `sonnet-4-6`, `opus-4-7`, `haiku-4-5` resolve correctly
- **Tool schema hint** — injected into system prompt so models without native tool-schema context still see argument structure

### Performance & stability
- **`model_copy` instead of `deepcopy`** — O(1) vs O(n_tools) per trimmed request
- **Async log enqueue** — removes startup truncation; all first-line logs now preserved
- **Fix: tokens.py syntax error** — `except TypeError, ValueError:` was Python 2 syntax; fixed

## Environment variables
| Variable | Default | Description |
|---|---|---|
| `MAX_MESSAGES` | 0 | Max messages sent to provider (0 = unlimited) |
| `CONTEXT_MAX_TOKENS` | 0 | Token budget including tool schemas (0 = unlimited) |
| `CONTEXT_MIN_MESSAGES` | 20 | Floor for seam-walker fallback |
| `NIM_MAX_MESSAGES` | 0 | NIM-specific override (0 = inherit global) |
| `NIM_CONTEXT_MAX_TOKENS` | 0 | NIM-specific override |
| `NIM_CONTEXT_MIN_MESSAGES` | 0 | NIM-specific override |
| `OPENROUTER_MAX_MESSAGES` | 0 | OR-specific override |
| `OPENROUTER_CONTEXT_MAX_TOKENS` | 0 | OR-specific override |
| `OPENROUTER_CONTEXT_MIN_MESSAGES` | 0 | OR-specific override |
| `OPENROUTER_INCLUDE_PAID_MODELS` | false | Surface paid OR models in /model picker |
| `OPENROUTER_ENABLE_THINKING` | false | Reasoning mode for OR routes |
| `NIM_PARALLEL_TOOL_CALLS` | true | Set false to serialize tool calls |

## Test plan
- [ ] Long session (>120k tokens) trims cleanly, no `trimmed N → 0` events
- [ ] Tool-heavy session with 91+ tools stays within token budget
- [ ] `<function=NAME>...</function>` without bullet emits `tool_use` block (not raw text)
- [ ] `OPENROUTER_INCLUDE_PAID_MODELS=true` lists paid Qwen models in `/v1/models`
- [ ] Default behavior (`OPENROUTER_INCLUDE_PAID_MODELS` unset) lists free models only — backward compatible
- [ ] `qwen3-235b-a22b-thinking-2507` auto-enables thinking on OR routes
- [ ] `NIM_CONTEXT_MAX_TOKENS=120000` + `OPENROUTER_CONTEXT_MAX_TOKENS=800000` apply per-provider when routing
- [ ] `sonnet-4-6` / `opus-4-7` resolve to correct NIM endpoints