### PR TITLE
Implement metrics tracking middleware and endpoints for API requests

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application factory and configuration."""
 
+import json
 import traceback
 from contextlib import asynccontextmanager
 from typing import Any
@@ -13,6 +14,7 @@ from starlette.types import Receive, Scope, Send
 
 from config.logging_config import configure_logging
 from config.settings import get_settings
+from core.metrics import get_metrics_service
 from providers.exceptions import ProviderError
 
 from .routes import router
@@ -96,6 +98,33 @@ def create_app(*, lifespan_enabled: bool = True) -> FastAPI:
 
     # Register routes
     app.include_router(router)
+
+    # Middleware for metrics tracking
+    @app.middleware("http")
+    async def metrics_middleware(request: Request, call_next):
+        """Track API request metrics by model."""
+        if request.url.path == "/v1/messages" and request.method == "POST":
+            try:
+                # Receive and cache the body for later use
+                body = await request.body()
+                if body:
+                    try:
+                        body_dict = json.loads(body)
+                        model_id = body_dict.get("model", "unknown")
+                        get_metrics_service().record_request(model_id)
+                    except (json.JSONDecodeError, ValueError):
+                        logger.debug("Failed to parse request body for metrics")
+                
+                # Recreate the request so the route handler can read it
+                async def receive():
+                    return {"type": "http.request", "body": body, "more_body": False}
+                
+                request._receive = receive
+            except Exception as e:
+                logger.debug("Metrics middleware error: {}", e)
+        
+        response = await call_next(request)
+        return response
 
     # Exception handlers
     @app.exception_handler(RequestValidationError)

--- a/api/routes.py
+++ b/api/routes.py
@@ -5,6 +5,7 @@ from loguru import logger
 
 from config.settings import Settings
 from core.anthropic import get_token_count
+from core.metrics import get_metrics_service
 from providers.registry import ProviderRegistry
 
 from . import dependencies
@@ -252,3 +253,30 @@ async def stop_cli(request: Request, _auth=Depends(require_api_key)):
     count = await handler.stop_all_tasks()
     logger.info("STOP_CLI: source=handler cancelled_count={}", count)
     return {"status": "stopped", "cancelled_count": count}
+
+
+@router.get("/metrics")
+async def get_metrics_endpoint(hours: int = 24, _auth=Depends(require_api_key)):
+    """Get request metrics by model and hour.
+    
+    Query parameters:
+    - hours: Number of recent hours to include (default 24)
+    
+    Returns metrics grouped by model with request counts per hour.
+    """
+    metrics_service = get_metrics_service()
+    return metrics_service.get_metrics(hours=hours)
+
+
+@router.get("/metrics/summary")
+async def get_metrics_summary(_auth=Depends(require_api_key)):
+    """Get summary of request metrics by model (total requests per model)."""
+    metrics_service = get_metrics_service()
+    return metrics_service.get_model_summary()
+
+
+@router.get("/metrics/hourly")
+async def get_metrics_hourly(hours: int = 24, _auth=Depends(require_api_key)):
+    """Get hourly summary of request metrics across all models."""
+    metrics_service = get_metrics_service()
+    return metrics_service.get_hourly_summary(hours=hours)

--- a/core/metrics.py
+++ b/core/metrics.py
@@ -1,0 +1,150 @@
+"""Request metrics tracking service.
+
+Tracks the number of API requests per model per hour.
+"""
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from loguru import logger
+
+
+class MetricsService:
+    """Tracks and aggregates request metrics by model and hour."""
+
+    def __init__(self):
+        # Structure: {model_id: {hour_key: request_count}}
+        self._metrics: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+        self._lock = None  # For thread-safety if needed
+
+    @staticmethod
+    def _get_hour_key(dt: datetime | None = None) -> str:
+        """Get hour key in format 'YYYY-MM-DD-HH' (UTC)."""
+        if dt is None:
+            dt = datetime.now(timezone.utc)
+        return dt.strftime("%Y-%m-%d-%H")
+
+    def record_request(self, model_id: str) -> None:
+        """Record a single request for a model.
+
+        Args:
+            model_id: The Claude model ID (e.g., "claude-opus-4-20250514")
+        """
+        if not model_id:
+            model_id = "unknown"
+
+        hour_key = self._get_hour_key()
+        self._metrics[model_id][hour_key] += 1
+        logger.debug(f"Metrics recorded: model={model_id}, hour={hour_key}")
+
+    def get_metrics(
+        self, hours: int = 24, model_id: str | None = None
+    ) -> dict[str, Any]:
+        """Get aggregated metrics.
+
+        Args:
+            hours: Number of recent hours to include (default 24)
+            model_id: Filter to specific model, or None for all models
+
+        Returns:
+            Dictionary with metrics grouped by model and hour
+        """
+        result = {}
+
+        # Determine which models to include
+        models_to_include = (
+            [model_id] if model_id and model_id in self._metrics else self._metrics.keys()
+        )
+
+        for model in sorted(models_to_include):
+            model_data = {}
+
+            # Get all hours for this model
+            for hour_key in sorted(self._metrics[model].keys()):
+                model_data[hour_key] = self._metrics[model][hour_key]
+
+            if model_data:
+                result[model] = model_data
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "models": result,
+            "summary": self._compute_summary(result),
+        }
+
+    def get_hourly_summary(self, hours: int = 24) -> dict[str, Any]:
+        """Get hourly summary across all models.
+
+        Args:
+            hours: Number of recent hours to include
+
+        Returns:
+            Dictionary with total requests per hour
+        """
+        hourly_totals: dict[str, int] = defaultdict(int)
+
+        for model_id, hour_data in self._metrics.items():
+            for hour_key, count in hour_data.items():
+                hourly_totals[hour_key] += count
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "hourly": {
+                hour_key: count for hour_key, count in sorted(hourly_totals.items())
+            },
+        }
+
+    def get_model_summary(self) -> dict[str, Any]:
+        """Get summary by model (total requests per model)."""
+        model_totals: dict[str, int] = {}
+
+        for model_id, hour_data in self._metrics.items():
+            model_totals[model_id] = sum(hour_data.values())
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "models": {
+                model_id: count
+                for model_id, count in sorted(
+                    model_totals.items(), key=lambda x: x[1], reverse=True
+                )
+            },
+            "total_requests": sum(model_totals.values()),
+        }
+
+    def _compute_summary(self, metrics: dict[str, dict[str, int]]) -> dict[str, Any]:
+        """Compute summary statistics from metrics."""
+        total_requests = 0
+        model_count = len(metrics)
+        hour_count = 0
+        requests_per_model = {}
+
+        for model_id, hour_data in metrics.items():
+            model_total = sum(hour_data.values())
+            requests_per_model[model_id] = model_total
+            total_requests += model_total
+
+            if hour_count == 0:
+                hour_count = len(hour_data)
+
+        return {
+            "total_requests": total_requests,
+            "model_count": model_count,
+            "hour_count": hour_count,
+            "requests_per_model": requests_per_model,
+        }
+
+    def reset_metrics(self) -> None:
+        """Clear all metrics (for testing or maintenance)."""
+        self._metrics.clear()
+        logger.info("Metrics cleared")
+
+
+# Global metrics instance
+_metrics_service = MetricsService()
+
+
+def get_metrics_service() -> MetricsService:
+    """Get the global metrics service instance."""
+    return _metrics_service

--- a/test_metrics.py
+++ b/test_metrics.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+"""Test script to verify metrics endpoints."""
+
+import httpx
+import json
+from datetime import datetime
+
+BASE_URL = "http://localhost:8082"
+AUTH_TOKEN = "freecc"  # ANTHROPIC_AUTH_TOKEN
+
+
+async def test_metrics():
+    """Test the metrics endpoints."""
+    async with httpx.AsyncClient() as client:
+        headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
+
+        # Get full metrics (by model and hour)
+        print("=" * 60)
+        print("📊 FULL METRICS (by model and hour)")
+        print("=" * 60)
+        response = await client.get(f"{BASE_URL}/metrics", headers=headers)
+        if response.status_code == 200:
+            metrics = response.json()
+            print(json.dumps(metrics, indent=2))
+        else:
+            print(f"❌ Error: {response.status_code}")
+            print(response.text)
+
+        # Get model summary
+        print("\n" + "=" * 60)
+        print("📈 MODEL SUMMARY (total requests per model)")
+        print("=" * 60)
+        response = await client.get(f"{BASE_URL}/metrics/summary", headers=headers)
+        if response.status_code == 200:
+            summary = response.json()
+            print(json.dumps(summary, indent=2))
+        else:
+            print(f"❌ Error: {response.status_code}")
+            print(response.text)
+
+        # Get hourly summary
+        print("\n" + "=" * 60)
+        print("⏰ HOURLY SUMMARY (total requests per hour)")
+        print("=" * 60)
+        response = await client.get(f"{BASE_URL}/metrics/hourly", headers=headers)
+        if response.status_code == 200:
+            hourly = response.json()
+            print(json.dumps(hourly, indent=2))
+        else:
+            print(f"❌ Error: {response.status_code}")
+            print(response.text)
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    print(f"Testing metrics endpoints at {BASE_URL}\n")
+    print(f"Auth token: {AUTH_TOKEN}\n")
+    asyncio.run(test_metrics())


### PR DESCRIPTION
This pull request introduces a new request metrics tracking system for the API, enabling the collection and reporting of API request counts per model and per hour. It adds middleware to track requests, a new `MetricsService` for aggregation, several new metrics endpoints, and a test script for verification.

**Metrics tracking and aggregation:**

* Added a new `core/metrics.py` module that defines a `MetricsService` class for tracking API requests by model and hour, providing methods to record requests and retrieve metrics summaries. A global instance is made available via `get_metrics_service()`.

* Integrated metrics tracking middleware in `api/app.py` that intercepts POST requests to `/v1/messages`, extracts the model from the request body, and records the request using the metrics service.

**API endpoints for metrics:**

* Added three new endpoints in `api/routes.py`:
  - `/metrics`: Returns detailed request counts by model and hour.
  - `/metrics/summary`: Returns total requests per model.
  - `/metrics/hourly`: Returns total requests per hour across all models.  
  All endpoints require API key authentication.

**Testing and developer experience:**

* Added `test_metrics.py`, an async test script that queries the new metrics endpoints and prints their output for easy verification.

**Supporting changes:**

* Updated imports in `api/app.py` and `api/routes.py` to include `get_metrics_service`. [[1]](diffhunk://#diff-845cc75ff982ceed9ec9c20860c51797b53e8647ef806df9046183e231cef477R3) [[2]](diffhunk://#diff-845cc75ff982ceed9ec9c20860c51797b53e8647ef806df9046183e231cef477R17) [[3]](diffhunk://#diff-e8bf8155ecc27651ffc56921d9f536dc9717374e8315f9f1cf384ac08513f621R8)