### PR TITLE
feat(routes): add Claude 4 short-form model IDs for Claude Code 2.1.x compatibility

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -20,6 +20,23 @@ DISCOVERED_MODEL_CREATED_AT = "1970-01-01T00:00:00Z"
 
 
 SUPPORTED_CLAUDE_MODELS = [
+    # Claude 4 family (current)
+    ModelResponse(
+        id="claude-opus-4-7",
+        display_name="Claude Opus 4.7",
+        created_at="2025-10-01T00:00:00Z",
+    ),
+    ModelResponse(
+        id="claude-sonnet-4-6",
+        display_name="Claude Sonnet 4.6",
+        created_at="2025-10-01T00:00:00Z",
+    ),
+    ModelResponse(
+        id="claude-haiku-4-5-20251001",
+        display_name="Claude Haiku 4.5",
+        created_at="2025-10-01T00:00:00Z",
+    ),
+    # Claude 4 family (legacy date-suffix IDs)
     ModelResponse(
         id="claude-opus-4-20250514",
         display_name="Claude Opus 4",
@@ -35,6 +52,7 @@ SUPPORTED_CLAUDE_MODELS = [
         display_name="Claude Haiku 4",
         created_at="2025-05-14T00:00:00Z",
     ),
+    # Claude 3.x family
     ModelResponse(
         id="claude-3-opus-20240229",
         display_name="Claude 3 Opus",


### PR DESCRIPTION
## Problem

Claude Code 2.1.x sends model IDs **without** date suffixes:
- `claude-sonnet-4-6`
- `claude-opus-4-7`
- `claude-haiku-4-5-20251001`

The existing `SUPPORTED_CLAUDE_MODELS` list only had date-suffix variants (`claude-opus-4-20250514` etc.). On strict upstream providers that validate against the models list, this caused **model not found** errors for all current Claude Code requests.

## Changes

- Added short-form IDs as primary entries in `SUPPORTED_CLAUDE_MODELS`
- Kept date-suffix variants for backward compatibility with older Claude Code versions
- Added comment delimiters grouping entries by model family for readability

## Test plan

- [ ] `GET /v1/models` returns `claude-sonnet-4-6`, `claude-opus-4-7`, `claude-haiku-4-5-20251001`
- [ ] Existing date-suffix IDs still present (backward compat)
- [ ] Claude Code 2.1.x connects without "model not found" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)