### PR TITLE
Remove redundant powershell command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,6 @@ cd free-claude-code
 cp .env.example .env
 ```
 
-PowerShell uses:
-
-```powershell
-Copy-Item .env.example .env
-```
-
 Edit `.env` and choose one provider. For the default NVIDIA NIM path:
 
 ```dotenv


### PR DESCRIPTION
`cp` works just fine on powershell. no need.