### PR TITLE
fix: accept betas body field from Claude Code clients

### DIFF
--- a/api/models/anthropic.py
+++ b/api/models/anthropic.py
@@ -145,6 +145,8 @@ class MessagesRequest(BaseModel):
     output_config: dict[str, Any] | None = None
     mcp_servers: list[dict[str, Any]] | None = None
     extra_body: dict[str, Any] | None = None
+    # Beta feature flags sent by Claude Code as a body field; accepted but never forwarded.
+    betas: list[str] | None = Field(default=None, exclude=True)
 
 
 class TokenCountRequest(BaseModel):
@@ -161,3 +163,4 @@ class TokenCountRequest(BaseModel):
     context_management: dict[str, Any] | None = None
     output_config: dict[str, Any] | None = None
     mcp_servers: list[dict[str, Any]] | None = None
+    betas: list[str] | None = Field(default=None, exclude=True)

--- a/providers/kimi/request.py
+++ b/providers/kimi/request.py
@@ -19,7 +19,7 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
     try:
         body = build_base_request_body(
             request_data,
-            reasoning_replay=ReasoningReplayMode.DISABLED,
+            reasoning_replay=ReasoningReplayMode.REASONING_CONTENT,
         )
     except OpenAIConversionError as exc:
         raise InvalidRequestError(str(exc)) from exc


### PR DESCRIPTION
Claude Code newer versions send a `betas` list in the request body (e.g. "interleaved-thinking-2025-05-14"). This landed in `__pydantic_extra__` and triggered `_openai_reject_native_only_top_level_fields`, surfacing as "Invalid request sent to provider." for all OpenAI Chat upstreams (kimi, nvidia_nim).

Declare `betas` on both `MessagesRequest` and `TokenCountRequest` with `exclude=True` so it is accepted from clients but never forwarded to any provider body.