### PR TITLE
fix(kimi): inline tool schema $refs to satisfy Moonshot validator

### DIFF
--- a/providers/kimi/request.py
+++ b/providers/kimi/request.py
@@ -1,5 +1,6 @@
 """Request builder for Kimi (Moonshot) provider."""
 
+import copy
 from typing import Any
 
 from loguru import logger
@@ -7,6 +8,81 @@ from loguru import logger
 from core.anthropic import ReasoningReplayMode, build_base_request_body
 from core.anthropic.conversion import OpenAIConversionError
 from providers.exceptions import InvalidRequestError
+
+
+def _resolve_ref(ref: str, root: dict) -> dict | None:
+    """Resolve a local JSON pointer like '#/$defs/Foo' against root."""
+    if not isinstance(ref, str) or not ref.startswith("#/"):
+        return None
+    node: Any = root
+    for part in ref[2:].split("/"):
+        part = part.replace("~1", "/").replace("~0", "~")
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        else:
+            return None
+    return node if isinstance(node, dict) else None
+
+
+def _inline_refs(node: Any, root: dict, seen: frozenset = frozenset()) -> Any:
+    """Recursively inline $ref pointers and drop sibling keywords next to $ref.
+
+    Moonshot's flavored JSON Schema rejects siblings (description, etc.) next
+    to $ref because expansion produces conflicting keywords. Resolve refs
+    against root and replace the wrapping object outright.
+    """
+    if isinstance(node, dict):
+        if "$ref" in node:
+            ref = node["$ref"]
+            if ref in seen:
+                clone = {k: v for k, v in node.items() if k != "$ref"}
+                clone["type"] = clone.get("type", "object")
+                return clone
+            target = _resolve_ref(ref, root)
+            if target is not None:
+                merged = _inline_refs(target, root, seen | {ref})
+                if isinstance(merged, dict):
+                    out = dict(merged)
+                    for k, v in node.items():
+                        if k == "$ref":
+                            continue
+                        out.setdefault(k, v)
+                    return out
+                return merged
+            return {k: v for k, v in node.items() if k != "$ref"}
+        return {k: _inline_refs(v, root, seen) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_inline_refs(item, root, seen) for item in node]
+    return node
+
+
+def _sanitize_tool_parameters(params: dict) -> dict:
+    """Inline $ref/$defs and strip sibling-conflict keys for Moonshot."""
+    if not isinstance(params, dict):
+        return params
+    resolved = _inline_refs(copy.deepcopy(params), params)
+    if isinstance(resolved, dict):
+        resolved.pop("$defs", None)
+        resolved.pop("definitions", None)
+    return resolved
+
+
+def _sanitize_tools(tools: list) -> list:
+    out = []
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            out.append(tool)
+            continue
+        new_tool = dict(tool)
+        fn = new_tool.get("function")
+        if isinstance(fn, dict):
+            new_fn = dict(fn)
+            params = new_fn.get("parameters")
+            if isinstance(params, dict):
+                new_fn["parameters"] = _sanitize_tool_parameters(params)
+            new_tool["function"] = new_fn
+        out.append(new_tool)
+    return out
 
 
 def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
@@ -23,6 +99,9 @@ def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
         )
     except OpenAIConversionError as exc:
         raise InvalidRequestError(str(exc)) from exc
+
+    if "tools" in body:
+        body["tools"] = _sanitize_tools(body["tools"])
 
     logger.debug(
         "KIMI_REQUEST: conversion done model={} msgs={} tools={}",

--- a/tests/providers/test_kimi_request.py
+++ b/tests/providers/test_kimi_request.py
@@ -1,0 +1,190 @@
+"""Tests for providers/kimi/request.py — Moonshot-flavored schema sanitization."""
+
+from typing import Any, cast
+
+from providers.kimi.request import (
+    _inline_refs,
+    _sanitize_tool_parameters,
+    _sanitize_tools,
+)
+
+
+class TestSanitizeToolParameters:
+    def test_inlines_local_ref_and_drops_defs(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "color": {
+                    "$ref": "#/$defs/LabelColor",
+                    "description": "Sibling description.",
+                },
+            },
+            "$defs": {
+                "LabelColor": {
+                    "description": "Target description.",
+                    "type": "object",
+                    "properties": {
+                        "backgroundColor": {"type": "string"},
+                    },
+                },
+            },
+        }
+
+        out = _sanitize_tool_parameters(schema)
+
+        color = out["properties"]["color"]
+        assert "$ref" not in color
+        assert color["type"] == "object"
+        assert color["properties"]["backgroundColor"]["type"] == "string"
+        assert "$defs" not in out
+
+    def test_sibling_description_does_not_overwrite_target(self):
+        schema = {
+            "properties": {
+                "color": {
+                    "$ref": "#/$defs/LabelColor",
+                    "description": "Sibling description.",
+                },
+            },
+            "$defs": {
+                "LabelColor": {
+                    "description": "Target description.",
+                    "type": "object",
+                },
+            },
+        }
+
+        out = _sanitize_tool_parameters(schema)
+
+        # Target wins; only one description survives so no Moonshot conflict.
+        assert out["properties"]["color"]["description"] == "Target description."
+
+    def test_sibling_keys_kept_when_target_lacks_them(self):
+        schema = {
+            "properties": {
+                "x": {
+                    "$ref": "#/$defs/Plain",
+                    "description": "Only on sibling.",
+                },
+            },
+            "$defs": {"Plain": {"type": "string"}},
+        }
+
+        out = _sanitize_tool_parameters(schema)
+
+        assert out["properties"]["x"]["type"] == "string"
+        assert out["properties"]["x"]["description"] == "Only on sibling."
+
+    def test_definitions_alias_also_dropped(self):
+        schema = {
+            "properties": {"x": {"$ref": "#/definitions/Foo"}},
+            "definitions": {"Foo": {"type": "string"}},
+        }
+
+        out = _sanitize_tool_parameters(schema)
+
+        assert "definitions" not in out
+        assert out["properties"]["x"]["type"] == "string"
+
+    def test_unresolvable_ref_drops_ref_keeps_siblings(self):
+        schema = {
+            "properties": {
+                "x": {"$ref": "#/$defs/Missing", "type": "string"},
+            },
+        }
+
+        out = _sanitize_tool_parameters(schema)
+
+        assert "$ref" not in out["properties"]["x"]
+        assert out["properties"]["x"]["type"] == "string"
+
+    def test_circular_ref_does_not_recurse_forever(self):
+        schema = {
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {"child": {"$ref": "#/$defs/Node"}},
+                },
+            },
+            "properties": {"root": {"$ref": "#/$defs/Node"}},
+        }
+
+        out = _sanitize_tool_parameters(schema)
+
+        # Outer expansion happens once; inner self-ref breaks cycle.
+        root = out["properties"]["root"]
+        assert root["type"] == "object"
+        assert "$ref" not in root["properties"]["child"]
+
+    def test_does_not_mutate_input(self):
+        schema = {
+            "properties": {"x": {"$ref": "#/$defs/Foo"}},
+            "$defs": {"Foo": {"type": "string"}},
+        }
+
+        _sanitize_tool_parameters(schema)
+
+        assert schema["properties"]["x"] == {"$ref": "#/$defs/Foo"}
+        assert "$defs" in schema
+
+    def test_non_dict_input_passes_through(self):
+        assert _sanitize_tool_parameters(cast(Any, [])) == []
+        assert _sanitize_tool_parameters(cast(Any, "x")) == "x"
+
+
+class TestInlineRefs:
+    def test_nested_lists_are_walked(self):
+        root = {"$defs": {"S": {"type": "string"}}}
+        node = {"oneOf": [{"$ref": "#/$defs/S"}, {"type": "integer"}]}
+
+        out = _inline_refs(node, root)
+
+        assert out == {"oneOf": [{"type": "string"}, {"type": "integer"}]}
+
+    def test_passthrough_for_non_container(self):
+        assert _inline_refs(42, {}) == 42
+        assert _inline_refs(None, {}) is None
+
+
+class TestSanitizeTools:
+    def test_walks_tools_function_parameters(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "create_label",
+                    "parameters": {
+                        "properties": {
+                            "color": {
+                                "$ref": "#/$defs/LabelColor",
+                                "description": "sibling",
+                            },
+                        },
+                        "$defs": {
+                            "LabelColor": {
+                                "description": "target",
+                                "type": "object",
+                            },
+                        },
+                    },
+                },
+            },
+        ]
+
+        out = _sanitize_tools(tools)
+
+        params = out[0]["function"]["parameters"]
+        assert "$defs" not in params
+        assert "$ref" not in params["properties"]["color"]
+
+    def test_tool_without_function_passes_through(self):
+        tools = [{"type": "other", "name": "x"}]
+        assert _sanitize_tools(tools) == tools
+
+    def test_function_without_parameters_unchanged(self):
+        tools = [{"type": "function", "function": {"name": "noop"}}]
+        assert _sanitize_tools(tools) == tools
+
+    def test_empty_or_none_tools(self):
+        assert _sanitize_tools([]) == []
+        assert _sanitize_tools(cast(Any, None)) == []


### PR DESCRIPTION
## Summary

- Moonshot's "flavored" JSON Schema validator rejects `$ref` siblings: after expansion, sibling keywords (e.g. `description`) collide with the target's keys and the request fails with HTTP 400.
- Claude Code MCP tools like `mcp__claude_ai_Gmail__create_label` ship schemas with `{"$ref": "...", "description": "..."}` pairs, so every tool-using request to `kimi/*` blows up before reaching the model.
- Sanitize tool schemas in the Kimi request builder: inline local `$ref` pointers, drop `$defs`/`definitions`, and let the target's keys win over siblings on collision. Result is a flat schema Moonshot accepts.

## Reproduction

With `MODEL=kimi/kimi-k2.6` and Claude Code 2.1.132 connected through the proxy:

```
❯ /model
  ⎿ Set model to anthropic/kimi/kimi-k2.6
❯ crie uma função para calcular palindromo
⏺ Invalid request sent to provider. (request_id=req_cb97980e253a)
```

`server.log` (with `LOG_API_ERROR_TRACEBACKS=true`):

```
KIMI_ERROR: request_id=req_cb97980e253a BadRequestError: Error code: 400 -
{'error': {'message': "Invalid request: tools.function.parameters is not a
valid moonshot flavored json schema, details: <At path 'properties.color':
conflicting keywords found after $ref expansion: description>",
'type': 'invalid_request_error'}}
```

The offending tool schema:

```json
{
  "type": "object",
  "properties": {
    "color": {
      "$ref": "#/$defs/LabelColor",
      "description": "Optional. The color of the label."
    }
  },
  "$defs": {
    "LabelColor": {
      "description": "The color of the label.",
      "type": "object",
      "properties": { "...": "..." }
    }
  }
}
```

After expansion `properties.color` would carry two `description` keys → Moonshot 400.

## Fix

`providers/kimi/request.py` adds:

- `_resolve_ref` — walks `#/...` pointers against the schema root.
- `_inline_refs` — recursively replaces `{"$ref": ..., ...siblings}` with the resolved target; siblings only fill keys the target lacks (`setdefault`), so no key ever appears twice. Cycle-safe via a `seen` set.
- `_sanitize_tool_parameters` / `_sanitize_tools` — entry points that deep-copy, drop `$defs`/`definitions`, and walk every `tools[].function.parameters` once before the request leaves the proxy.

`build_request_body` runs the sanitizer after the existing OpenAI-format conversion, so the Anthropic→OpenAI conversion path is untouched.

## Test plan

- [x] `uv run ruff format` — 233 files unchanged.
- [x] `uv run ruff check` — passed.
- [x] `uv run ty check` — passed.
- [x] `uv run pytest` — 1211 passed (14 new in `tests/providers/test_kimi_request.py`).
- [x] Manual: relaunched proxy with `kimi/kimi-k2.6`, ran a tool-using prompt end-to-end, no more 400 from `properties.color`.

New tests cover: ref inlining, `$defs` removal, sibling-merge precedence (target wins), `definitions` alias dropped, unresolvable refs, circular refs, list traversal, non-mutation of input, and the full `tools[]` walker.

## Residual Risks

- Sibling-key precedence favors the `$ref` target over the wrapping object. In practice this means a per-property `description` written next to a `$ref` is replaced by the `$ref` target's `description`. This is the only resolution that satisfies Moonshot; the alternative (sibling wins) would require also rewriting the target, which mutates shared `$defs`. Tool semantics remain intact (parameter shape, types, required keys are identical post-inline).
- Sanitizer is Kimi-only on purpose; other providers may want similar handling separately if they expose the same constraint.