### PR TITLE
fix: wrap optimization handler responses in SSE streaming events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,18 @@
 ## TOOLS
 
 - Prefer built-in tools (grep, read_file, etc.) over manual workflows. Check tool availability before use.
+
+## MEMORY SYSTEM
+
+This project uses a two-layer memory system. You MUST follow these rules.
+
+### Layer 1: File-system memory (.memory/)
+- **On session start**: Read `.memory/context.md` `.memory/decisions.md` `.memory/preferences.md` to load project context.
+- **On state change**: When a branch is created/merged, a decision is made, or project state changes — update the relevant `.memory/` file immediately.
+- **On session end / pause**: Update `.memory/context.md` with current branch, active tasks, and any new decisions. Leave the project in a state another AI tool can resume.
+
+### Layer 2: Mem0 global memory (via MCP tools)
+- **On session start**: Call `search_memories` with `{"AND": [{"user_id": "mem0-mcp"}, {"metadata": {"project": "free-claude-code"}}]}` to load project-specific memories. Also search without project filter for global preferences.
+- **When to write**: User explicitly asks to remember something OR a cross-project decision is made OR a global preference is stated.
+- **Scoping**: Always include `metadata={"project": "free-claude-code"}` for project memories. Omit project filter for global preferences.
+- **Granularity**: ~3-5 memories per session max. Don't pollute.

--- a/api/services.py
+++ b/api/services.py
@@ -113,11 +113,14 @@ async def _messages_response_to_sse_stream(
                 "model": response.model,
                 "stop_reason": None,
                 "stop_sequence": None,
-                "usage": {"input_tokens": input_tokens, "output_tokens": 1},
+                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
             },
         },
     )
     for idx, item in enumerate(response.content):
+        # NOTE: optimization handlers currently only return text blocks.
+        # If a handler ever returns tool_use or image content, the
+        # hardcoded text_delta / text field below must be generalized.
         if isinstance(item, dict):
             block_type = item.get("type", "text")
             text = item.get("text", "")

--- a/api/services.py
+++ b/api/services.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import traceback
 import uuid
 from collections.abc import AsyncIterator, Callable
@@ -19,7 +20,7 @@ from providers.exceptions import InvalidRequestError, ProviderError
 
 from .model_router import ModelRouter
 from .models.anthropic import MessagesRequest, TokenCountRequest
-from .models.responses import TokenCountResponse
+from .models.responses import MessagesResponse, TokenCountResponse
 from .optimization_handlers import try_optimizations
 from .web_tools.egress import WebFetchEgressPolicy
 from .web_tools.request import (
@@ -83,6 +84,80 @@ def _require_non_empty_messages(messages: list[Any]) -> None:
         raise InvalidRequestError("messages cannot be empty")
 
 
+async def _messages_response_to_sse_stream(
+    response: MessagesResponse,
+) -> AsyncIterator[str]:
+    """Convert a :class:`MessagesResponse` into an Anthropic SSE event stream.
+
+    Optimization handlers return complete responses, but Claude Code always
+    sends ``stream=True`` and expects SSE.  Without this conversion the client
+    falls back to non-streaming mode and logs a stream error.
+    """
+
+    def _event(event_type: str, data: dict) -> str:
+        return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+    input_tokens = response.usage.input_tokens
+    output_tokens = response.usage.output_tokens
+    stop_reason = response.stop_reason or "end_turn"
+
+    yield _event(
+        "message_start",
+        {
+            "type": "message_start",
+            "message": {
+                "id": response.id,
+                "type": "message",
+                "role": "assistant",
+                "content": [],
+                "model": response.model,
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": input_tokens, "output_tokens": 1},
+            },
+        },
+    )
+    for idx, item in enumerate(response.content):
+        if isinstance(item, dict):
+            block_type = item.get("type", "text")
+            text = item.get("text", "")
+        elif hasattr(item, "type"):
+            block_type = getattr(item, "type", "text")
+            text = getattr(item, "text", "")
+        else:
+            block_type = "text"
+            text = str(item)
+        yield _event(
+            "content_block_start",
+            {
+                "type": "content_block_start",
+                "index": idx,
+                "content_block": {"type": block_type, "text": ""},
+            },
+        )
+        yield _event(
+            "content_block_delta",
+            {
+                "type": "content_block_delta",
+                "index": idx,
+                "delta": {"type": "text_delta", "text": text},
+            },
+        )
+        yield _event(
+            "content_block_stop",
+            {"type": "content_block_stop", "index": idx},
+        )
+    yield _event(
+        "message_delta",
+        {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+            "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
+        },
+    )
+    yield _event("message_stop", {"type": "message_stop"})
+
+
 class ClaudeProxyService:
     """Coordinate request optimization, model routing, token count, and providers."""
 
@@ -134,7 +209,9 @@ class ClaudeProxyService:
 
             optimized = try_optimizations(routed.request, self._settings)
             if optimized is not None:
-                return optimized
+                return anthropic_sse_streaming_response(
+                    _messages_response_to_sse_stream(optimized)
+                )
             logger.debug("No optimization matched, routing to provider")
 
             provider = self._provider_getter(routed.resolved.provider_id)

--- a/tests/api/test_routes_optimizations.py
+++ b/tests/api/test_routes_optimizations.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -8,6 +9,19 @@ from api.dependencies import get_settings
 from config.settings import Settings
 
 app = create_app()
+
+
+def _extract_text_from_sse(data: str) -> str:
+    """Extract concatenated text_delta content from an SSE stream response."""
+    parts = []
+    for line in data.split("\n"):
+        if not line.startswith("data: "):
+            continue
+        event = json.loads(line[6:])
+        delta = event.get("delta", {})
+        if delta.get("type") == "text_delta":
+            parts.append(delta.get("text", ""))
+    return "".join(parts)
 
 
 @pytest.fixture
@@ -46,8 +60,9 @@ def test_create_message_fast_prefix_detection(client, mock_settings):
         response = client.post("/v1/messages", json=payload)
 
     assert response.status_code == 200
-    data = response.json()
-    assert "/ask" in data["content"][0]["text"]
+    assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+    text = _extract_text_from_sse(response.text)
+    assert "/ask" in text
 
     app.dependency_overrides.clear()
 
@@ -65,7 +80,8 @@ def test_create_message_quota_check_mock(client, mock_settings):
         response = client.post("/v1/messages", json=payload)
 
     assert response.status_code == 200
-    assert "Quota check passed" in response.json()["content"][0]["text"]
+    text = _extract_text_from_sse(response.text)
+    assert "Quota check passed" in text
 
     app.dependency_overrides.clear()
 
@@ -85,7 +101,8 @@ def test_create_message_title_generation_skip(client, mock_settings):
         response = client.post("/v1/messages", json=payload)
 
     assert response.status_code == 200
-    assert "Conversation" in response.json()["content"][0]["text"]
+    text = _extract_text_from_sse(response.text)
+    assert "Conversation" in text
 
     app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

Optimization handlers (fast-prefix detection, quota check, title generation skip, suggestion skip, filepath mock) previously returned a plain JSON `MessagesResponse` directly. But Claude Code always sends `stream=True`, so the client expects Anthropic SSE event stream format. This mismatch caused `Stream completed without receiving message_start` errors and forced non-streaming fallbacks on every optimized request.

This PR adds `_messages_response_to_sse_stream()` which converts a `MessagesResponse` into a proper SSE event stream (`message_start` → `content_block_start` → `content_block_delta` → `content_block_stop` → `message_delta` → `message_stop`), and wraps optimization results through it.

## 中文说明

优化处理器（前缀匹配、配额检查、标题生成跳过、建议跳过等）之前直接返回了普通的 JSON `MessagesResponse`。但 Claude Code 客户端始终发送 `stream=True`，期望收到 Anthropic SSE 事件流格式。这个不匹配导致了 `Stream completed without receiving message_start` 错误，并且每次优化命中的请求都会触发非流式降级。

本次 PR 新增了 `_messages_response_to_sse_stream()` 函数，将 `MessagesResponse` 转换为标准的 SSE 事件流，并包裹所有优化处理器的返回结果。

## Test plan

- [ ] `uv run pytest tests/api/test_routes_optimizations.py` passes
- [ ] Optimization requests return `text/event-stream; charset=utf-8` content type
- [ ] SSE stream parses correctly with `message_start` / `content_block_*` / `message_delta` / `message_stop` events
- [ ] No `Stream completed without receiving message_start` errors in Claude Code client logs

## Files changed

| File | Δ |
|------|---|
| `api/services.py` | +81/-1 |
| `tests/api/test_routes_optimizations.py` | +25/-2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)