### PR TITLE
Fix startup crash on read-only filesystems by falling back to stderr logging

### DIFF
--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -9,6 +9,7 @@ included at top level for easy grep/filter.
 import json
 import logging
 import re
+import sys
 from pathlib import Path
 
 from loguru import logger
@@ -93,18 +94,25 @@ def configure_logging(
     # Remove default loguru handler (writes to stderr)
     logger.remove()
 
-    # Truncate log file on fresh start for clean debugging
-    Path(log_file).write_text("")
+    try:
+        # Truncate log file on fresh start for clean debugging.
+        Path(log_file).write_text("")
 
-    # Add file sink: JSON lines, DEBUG level, context vars at top level
-    logger.add(
-        log_file,
-        level="DEBUG",
-        format=_serialize_with_context,
-        encoding="utf-8",
-        mode="a",
-        rotation="50 MB",
-    )
+        # Add file sink: JSON lines, DEBUG level, context vars at top level.
+        logger.add(
+            log_file,
+            level="DEBUG",
+            format=_serialize_with_context,
+            encoding="utf-8",
+            mode="a",
+            rotation="50 MB",
+        )
+    except OSError:
+        # Serverless environments can have read-only filesystems at import time.
+        logger.add(sys.stderr, level="DEBUG", format=_serialize_with_context)
+        logger.warning(
+            "Log file '{}' is not writable; using stderr sink instead", log_file
+        )
 
     # Intercept stdlib logging: route all root logger output to loguru
     intercept = InterceptHandler()

--- a/tests/config/test_logging_config.py
+++ b/tests/config/test_logging_config.py
@@ -1,5 +1,6 @@
 """Tests for config/logging_config.py."""
 
+import errno
 import json
 import logging
 from pathlib import Path
@@ -94,3 +95,17 @@ def test_httpx_resets_to_notset_when_verbose_third_party(tmp_path) -> None:
     log_file = str(tmp_path / "verbose.log")
     configure_logging(log_file, force=True, verbose_third_party=True)
     assert logging.getLogger("httpx").level == logging.NOTSET
+
+
+def test_configure_logging_falls_back_when_log_file_unwritable(
+    tmp_path, monkeypatch
+) -> None:
+    log_file = str(tmp_path / "readonly.log")
+
+    def _raise_readonly(*_args, **_kwargs) -> str:
+        raise OSError(errno.EROFS, "Read-only file system")
+
+    monkeypatch.setattr(Path, "write_text", _raise_readonly)
+
+    configure_logging(log_file, force=True)
+    logging.getLogger("test.readonly").info("falls back to stderr")


### PR DESCRIPTION
## Summary
- Prevent startup/import failure when the configured log file path is not writable (for example, serverless read-only filesystems such as Vercel).
- Keep logging available by falling back to a stderr sink when file sink initialization fails.
- Add regression coverage for the read-only filesystem path.

## Root Cause
`configure_logging()` attempted to truncate/create `server.log` during app startup. On read-only filesystems this raised `OSError: [Errno 30] Read-only file system`, causing module import and process startup to fail.

## Changes
- Wrap file-log setup in `try/except OSError` in `config/logging_config.py`.
- On failure, initialize loguru with `sys.stderr` sink and emit a warning.
- Add test `test_configure_logging_falls_back_when_log_file_unwritable` in `tests/config/test_logging_config.py`.

## Validation
- `uv run pytest tests/config/test_logging_config.py`
- `uv run ruff format`
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest`

All checks passed.
