### PR TITLE
feat(agent-governor): runtime safety for weak-RLHF agentic loops

### DIFF
--- a/api/agent_governor/README.md
+++ b/api/agent_governor/README.md
@@ -59,38 +59,76 @@ hurt strong-model behaviour.
    stop. Do not keep calling tools to double-check." Counters the bias of
    weak models to keep tool-calling instead of writing a final answer.
 
+## Size tiers
+
+A 30B nano model and a 480B coder cannot share one cap schedule. The governor
+classifies every non-frontier model into a **size tier** and uses tier-specific
+defaults. Pattern matching against the model id picks the tier automatically;
+manual overrides are available.
+
+| Tier       | Approx params | Examples                                                    | max consecutive | max total | tool cull | plan-mode default | termination hint |
+|------------|---------------|-------------------------------------------------------------|-----------------|-----------|-----------|-------------------|------------------|
+| `tiny`     | ≤30B          | nemotron-3-nano-30b, gpt-oss-20b, llama-8b, gemma-9b        | 4               | 20        | 15        | yes               | yes              |
+| `small`    | 30–80B        | qwen3-next-80b, llama-3.3-70b, nemotron-49b                 | 8               | 40        | 25        | yes               | yes              |
+| `medium`   | 80–200B       | nemotron-super-120b, gpt-oss-120b, glm-4.6, kimi-k2         | 15              | 80        | 35        | yes               | yes              |
+| `large`    | 200–400B      | llama-nemotron-ultra-253b, deepseek-v4-pro, qwen 235B       | 25              | 150       | 50        | no                | yes              |
+| `xl`       | 400–600B      | qwen3-coder-480b, llama-3.1-405b, hermes-3-405b, ring-1t    | 40              | 250       | 60        | no                | yes              |
+| `xxl`      | 600B+         | mistral-large-3-675b, future Qwen3-Max class                | 60              | 400       | 80        | no                | no               |
+| `frontier` | n/a           | claude-, gpt-5, gemini, grok                                | bypass          | bypass    | bypass    | n/a               | n/a              |
+
+Tier detection is substring-based, ordered largest → smallest. So
+`mistral-large-3-675b-instruct-2512` matches `xxl` (via `675b`) before any
+smaller pattern can match. MoE active-param suffixes like `a35b` are
+deliberately ignored — total params drive the tier.
+
+`large` and bigger turn off `plan-mode` by default because models in those
+tiers usually plan well on their own; the preamble can hurt their output
+quality. `xxl` also turns off `termination_hint` (frontier-adjacent reasoners
+like mistral-large-3 generally terminate themselves).
+
 ## Configuration
 
-All knobs are environment variables. Defaults are aggressive-but-safe.
+All knobs are environment variables. Defaults are aggressive-but-safe and
+tier-aware: setting a global env value overrides every tier; leaving it
+unset lets each model use its tier's defaults.
 
 ```bash
 # Master switch
 GOVERNOR_ENABLED=true                       # set false to disable everywhere
 
-# Hard limits
-GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=8
-GOVERNOR_MAX_TOTAL_TOOL_CALLS=40
-GOVERNOR_LOOP_REPEAT_THRESHOLD=3
-
-# Tool culling
+# Hard limits — UNSET means "use tier defaults". Setting any of these
+# overrides the tier default for ALL non-frontier models.
+GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=        # tier default (4–60)
+GOVERNOR_MAX_TOTAL_TOOL_CALLS=              # tier default (20–400)
+GOVERNOR_LOOP_REPEAT_THRESHOLD=3            # not tier-dependent
 GOVERNOR_TOOL_CULL_ENABLED=true
-GOVERNOR_TOOL_CULL_MAX=25
+GOVERNOR_TOOL_CULL_MAX=                     # tier default (15–80)
 
-# Weak-model preambles
-GOVERNOR_PLAN_MODE_FOR_WEAK=true
-GOVERNOR_TERMINATION_HINT_FOR_WEAK=true
+# Weak-model preambles — leave unset to follow per-tier defaults
+GOVERNOR_PLAN_MODE_FOR_WEAK=                # tier default
+GOVERNOR_TERMINATION_HINT_FOR_WEAK=         # tier default
+
+# Per-tier override JSON. Adjusts the tier defaults themselves.
+GOVERNOR_TIER_CAPS_JSON='{"xl":{"max_consecutive_tool_calls":60},"tiny":{"tool_cull_max":12}}'
 
 # Model classification (comma-separated lowercase substring patterns)
 GOVERNOR_WEAK_MODEL_PATTERNS=qwen,nemotron,deepseek-chat,deepseek-coder,kimi,moonshot,gpt-oss,glm,mistral,llama,wafer,ring,minimax,gemma,hermes,command,yi-
 GOVERNOR_STRONG_MODEL_PATTERNS=claude-,gpt-5,gpt-4,o1-,o3-,o4-,grok-,gemini-
 
-# Per-model overrides as a JSON object
-GOVERNOR_OVERRIDES_JSON='{"nvidia/nemotron-3-super-120b-a12b":{"max_consecutive_tool_calls":5,"plan_mode":true}}'
+# Per-model overrides as a JSON object. Highest precedence.
+# A "tier" field can pin a model into a specific tier explicitly.
+GOVERNOR_OVERRIDES_JSON='{"nvidia/nemotron-3-super-120b-a12b":{"max_consecutive_tool_calls":5,"plan_mode":true},"qwen3-coder-480b":{"tier":"xxl"}}'
 ```
 
 Override keys are matched as substrings against the request's model id; the
 longest matching key wins. This lets you write a generic rule like
 `{"qwen3-coder":{...}}` that catches every Qwen3 Coder variant.
+
+**Resolution order (highest → lowest precedence):**
+1. Per-model override (`GOVERNOR_OVERRIDES_JSON`)
+2. Process-level env value (e.g. `GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS`)
+3. Per-tier override (`GOVERNOR_TIER_CAPS_JSON`)
+4. Tier defaults (the table above)
 
 ## Telemetry
 

--- a/api/agent_governor/README.md
+++ b/api/agent_governor/README.md
@@ -1,0 +1,172 @@
+# Agent Governor
+
+Runtime safety layer for agentic loops on weak-RLHF (open-weight) models.
+
+Open-weight 80B–120B models (Qwen, Nemotron, DeepSeek, Kimi, GLM, GPT-OSS,
+Mistral, Llama) have weaker termination judgment than RLHF-tuned proprietary
+models (Claude, GPT-5). Without intervention they tool-call in tight loops and
+never emit `stop_reason=end_turn`. The proxy then accumulates 400+ messages and
+either burns through budgets or hangs on the upstream HTTP stream until the
+provider finally times out the connection (we observed an 8.5-hour hang).
+
+The governor inspects each `/v1/messages` request — after model routing, before
+provider streaming — and chooses one of three actions:
+
+| Action  | Meaning                                                     |
+|---------|-------------------------------------------------------------|
+| `pass`  | Forward the request unchanged.                               |
+| `augment` | Forward, but with culled tools / appended system prompt.   |
+| `abort` | Short-circuit with a forced "stop and answer" text response. |
+
+Strong models (any id matching `GOVERNOR_STRONG_MODEL_PATTERNS`, default
+`claude-`, `gpt-5`, `gpt-4`, `o1-`, `o3-`, `o4-`, `grok-`, `gemini-`) bypass the
+governor entirely. The interventions are designed for weak models and would
+hurt strong-model behaviour.
+
+## Interventions
+
+### Hard aborts (terminate the loop)
+
+1. **Total tool-call budget** (`GOVERNOR_MAX_TOTAL_TOOL_CALLS`, default 40)
+   Counts every `tool_use` block across the conversation. When the threshold
+   is hit, returns an Anthropic-shape response asking the user to start a
+   fresh session with a narrower task.
+2. **Loop signature** (`GOVERNOR_LOOP_REPEAT_THRESHOLD`, default 3)
+   The same tool name + the same arg hash, repeated N+ times in the recent
+   tool-call window, returns an abort response telling the model to try a
+   different approach.
+3. **Consecutive tool-call cap** (`GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS`,
+   default 8) — runs of `tool_use` (with intervening `tool_result` user
+   messages) without an assistant text turn or fresh user prompt. When hit,
+   tells the model to summarise what it has and stop.
+
+### Augmentations (modify the request, then continue)
+
+4. **Tool culling** (`GOVERNOR_TOOL_CULL_ENABLED`, default true,
+   `GOVERNOR_TOOL_CULL_MAX` default 25)
+   Free models drown in 91-tool inventories. Score each tool's name +
+   description against tokens extracted from recent user messages, keep the
+   top N plus a pinned "always keep" core (`read`, `write`, `edit`, `bash`,
+   `grep`, `glob`, `ls`, `todowrite`, `taskcreate`, `exitplanmode`,
+   `askuserquestion`, `webfetch`, `websearch`).
+5. **Plan-mode preamble** (`GOVERNOR_PLAN_MODE_FOR_WEAK`, default true)
+   Appends an instruction to the system prompt: *"Before calling any tool,
+   write a numbered plan with at most 5 short steps."* The plan acts as an
+   implicit termination signal — the model finishes the plan and stops.
+6. **Termination hint** (`GOVERNOR_TERMINATION_HINT_FOR_WEAK`, default true)
+   Tells the model that *text-only output is a valid answer*: "When you have
+   answered or cannot proceed, output your final answer as plain text and
+   stop. Do not keep calling tools to double-check." Counters the bias of
+   weak models to keep tool-calling instead of writing a final answer.
+
+## Configuration
+
+All knobs are environment variables. Defaults are aggressive-but-safe.
+
+```bash
+# Master switch
+GOVERNOR_ENABLED=true                       # set false to disable everywhere
+
+# Hard limits
+GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=8
+GOVERNOR_MAX_TOTAL_TOOL_CALLS=40
+GOVERNOR_LOOP_REPEAT_THRESHOLD=3
+
+# Tool culling
+GOVERNOR_TOOL_CULL_ENABLED=true
+GOVERNOR_TOOL_CULL_MAX=25
+
+# Weak-model preambles
+GOVERNOR_PLAN_MODE_FOR_WEAK=true
+GOVERNOR_TERMINATION_HINT_FOR_WEAK=true
+
+# Model classification (comma-separated lowercase substring patterns)
+GOVERNOR_WEAK_MODEL_PATTERNS=qwen,nemotron,deepseek-chat,deepseek-coder,kimi,moonshot,gpt-oss,glm,mistral,llama,wafer,ring,minimax,gemma,hermes,command,yi-
+GOVERNOR_STRONG_MODEL_PATTERNS=claude-,gpt-5,gpt-4,o1-,o3-,o4-,grok-,gemini-
+
+# Per-model overrides as a JSON object
+GOVERNOR_OVERRIDES_JSON='{"nvidia/nemotron-3-super-120b-a12b":{"max_consecutive_tool_calls":5,"plan_mode":true}}'
+```
+
+Override keys are matched as substrings against the request's model id; the
+longest matching key wins. This lets you write a generic rule like
+`{"qwen3-coder":{...}}` that catches every Qwen3 Coder variant.
+
+## Telemetry
+
+Each request emits one structured log line:
+
+```
+GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=pass     consecutive_tools=2 total_tools=11 tools_in=91
+GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=augment  consecutive_tools=3 total_tools=14 tools_in=91 tools_after_cull=25 intervention=tool_cull(-66),plan_mode,termination_hint
+GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=abort    consecutive_tools=8 total_tools=27 tools_in=25 intervention=consecutive_tools reason=cap_reached
+GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=abort    consecutive_tools=3 total_tools=14 tools_in=25 intervention=loop_signature reason=repeat:read
+GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=abort    consecutive_tools=15 total_tools=40 tools_in=25 reason=total_tool_budget_exceeded
+```
+
+Strong-model bypass and disabled-state are emitted at DEBUG level only.
+
+## Architecture
+
+```
+ClaudeProxyService.create_message
+  ├── ModelRouter.resolve  (provider routing)
+  ├── … existing checks …
+  ├── AgentGovernor.review                  ← THIS MODULE
+  │     ├── ConfigForModel
+  │     ├── compute_stats(messages)         (counts + recent tool sigs)
+  │     ├── HARD ABORTS:
+  │     │     1. total tool budget
+  │     │     2. loop signature
+  │     │     3. consecutive cap
+  │     ├── AUGMENTATIONS:
+  │     │     4. tool culling
+  │     │     5. plan-mode preamble
+  │     │     6. termination hint
+  │     └── log_decision()
+  ├── try_optimizations  (existing — title-gen, prefix detection, …)
+  └── provider.stream_response  (Anthropic ↔ OpenAI translation)
+```
+
+The governor is **stateless**: every decision is made from the request's
+own `messages` array. Claude Code re-sends the full conversation each turn,
+so no per-session storage is needed.
+
+## Why a governor instead of fine-tuning the model?
+
+Fine-tuning open-weight models for "good Claude-Code-like agent behaviour" is
+expensive, slow, and fragile across model versions. The governor is:
+
+* **External** — works with any model, any provider, any version.
+* **Stateless** — no per-session memory; safe under restarts.
+* **Reversible** — toggle via env, no behaviour change for strong models.
+* **Cheap** — pure Python over a parsed pydantic request, no extra LLM calls.
+
+Combined with the `claude-fcc` wrapper, this lets you get reliable agentic
+loops out of free models that would otherwise burn 8 hours on overnight
+infinite tool-call cycles.
+
+## Limitations
+
+* The governor cannot fix **NIM upstream flakiness** (502, RemoteProtocolError,
+  ReadTimeout). What it does fix: those failures now happen *fast* because
+  the abort path returns immediately rather than re-streaming endlessly.
+* The keyword-based tool-relevance scorer is **simple by design**. If a tool's
+  description is empty or generic, it scores poorly. If a project's MCP tool
+  authors give better descriptions, culling improves automatically.
+* The governor does **not** rewrite tool descriptions, fix tool schemas, or
+  intervene mid-stream — only at request boundaries.
+* **`AskUserQuestion`** is in the `ALWAYS_KEEP` list, so weak models can ask
+  for clarification — but the model still has to *choose* to use it. The
+  governor cannot force "ask the user" behaviour.
+
+## Future work
+
+* Embedding-based tool relevance (replace keyword scoring) — Phase 3 in the
+  original proposal, deferred until keyword scoring proves insufficient.
+* Per-MCP-server tool budgets (e.g. "at most 5 mempalace tools per request").
+* Adaptive caps based on observed model behaviour over the past N requests
+  (bandit-style: tighten caps for models that loop more often).
+* Optional `task` / `todowrite` synthesis: if the model isn't using these
+  tools but is in a long agentic chain, synthesise a fake "did you make a
+  todo?" turn that nudges it.

--- a/api/agent_governor/README.md
+++ b/api/agent_governor/README.md
@@ -72,8 +72,8 @@ manual overrides are available.
 | `small`    | 30–80B        | qwen3-next-80b, llama-3.3-70b, nemotron-49b                 | 8               | 40        | 25        | yes               | yes              |
 | `medium`   | 80–200B       | nemotron-super-120b, gpt-oss-120b, glm-4.6, kimi-k2         | 15              | 80        | 35        | yes               | yes              |
 | `large`    | 200–400B      | llama-nemotron-ultra-253b, deepseek-v4-pro, qwen 235B       | 25              | 150       | 50        | no                | yes              |
-| `xl`       | 400–600B      | qwen3-coder-480b, llama-3.1-405b, hermes-3-405b, ring-1t    | 40              | 250       | 60        | no                | yes              |
-| `xxl`      | 600B+         | mistral-large-3-675b, future Qwen3-Max class                | 60              | 400       | 80        | no                | no               |
+| `xl`       | 400–600B      | qwen3-coder-480b, llama-3.1-405b, hermes-3-405b, ring-1t    | 40              | 250       | 80        | no                | yes              |
+| `xxl`      | 600B+         | mistral-large-3-675b, future Qwen3-Max class                | 60              | 400       | 100       | no                | no               |
 | `frontier` | n/a           | claude-, gpt-5, gemini, grok                                | bypass          | bypass    | bypass    | n/a               | n/a              |
 
 Tier detection is substring-based, ordered largest → smallest. So
@@ -102,7 +102,7 @@ GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=        # tier default (4–60)
 GOVERNOR_MAX_TOTAL_TOOL_CALLS=              # tier default (20–400)
 GOVERNOR_LOOP_REPEAT_THRESHOLD=3            # not tier-dependent
 GOVERNOR_TOOL_CULL_ENABLED=true
-GOVERNOR_TOOL_CULL_MAX=                     # tier default (15–80)
+GOVERNOR_TOOL_CULL_MAX=                     # tier default (15–100)
 
 # Weak-model preambles — leave unset to follow per-tier defaults
 GOVERNOR_PLAN_MODE_FOR_WEAK=                # tier default

--- a/api/agent_governor/README.md
+++ b/api/agent_governor/README.md
@@ -72,8 +72,8 @@ manual overrides are available.
 | `small`    | 30–80B        | qwen3-next-80b, llama-3.3-70b, nemotron-49b                 | 8               | 40        | 25        | yes               | yes              |
 | `medium`   | 80–200B       | nemotron-super-120b, gpt-oss-120b, glm-4.6, kimi-k2         | 15              | 80        | 35        | yes               | yes              |
 | `large`    | 200–400B      | llama-nemotron-ultra-253b, deepseek-v4-pro, qwen 235B       | 25              | 150       | 50        | no                | yes              |
-| `xl`       | 400–600B      | qwen3-coder-480b, llama-3.1-405b, hermes-3-405b, ring-1t    | 40              | 250       | 80        | no                | yes              |
-| `xxl`      | 600B+         | mistral-large-3-675b, future Qwen3-Max class                | 60              | 400       | 100       | no                | no               |
+| `xl`       | 400–600B      | qwen3-coder-480b, llama-3.1-405b, hermes-3-405b, ring-1t    | 80              | 400       | 80        | no                | yes              |
+| `xxl`      | 600B+         | mistral-large-3-675b, future Qwen3-Max class                | 120             | 600       | 100       | no                | no               |
 | `frontier` | n/a           | claude-, gpt-5, gemini, grok                                | bypass          | bypass    | bypass    | n/a               | n/a              |
 
 Tier detection is substring-based, ordered largest → smallest. So
@@ -98,8 +98,8 @@ GOVERNOR_ENABLED=true                       # set false to disable everywhere
 
 # Hard limits — UNSET means "use tier defaults". Setting any of these
 # overrides the tier default for ALL non-frontier models.
-GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=        # tier default (4–60)
-GOVERNOR_MAX_TOTAL_TOOL_CALLS=              # tier default (20–400)
+GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=        # tier default (4–120)
+GOVERNOR_MAX_TOTAL_TOOL_CALLS=              # tier default (20–600)
 GOVERNOR_LOOP_REPEAT_THRESHOLD=3            # not tier-dependent
 GOVERNOR_TOOL_CULL_ENABLED=true
 GOVERNOR_TOOL_CULL_MAX=                     # tier default (15–100)

--- a/api/agent_governor/__init__.py
+++ b/api/agent_governor/__init__.py
@@ -1,0 +1,31 @@
+"""Agent Governor — runtime safety for weak-RLHF model agentic loops.
+
+The governor inspects each ``/v1/messages`` request, looks at conversation
+history and the tool list, and either:
+
+* lets the request through unchanged,
+* augments it (cull tools, prepend system hints, inject reflection turn), or
+* aborts with a forced "task budget exhausted" SSE response.
+
+It exists because open-weight 80B–120B models (Qwen, Nemotron, DeepSeek, Kimi,
+GLM, GPT-OSS, Mistral, Llama) have weaker termination judgment than RLHF-tuned
+proprietary models (Claude, GPT-5). Without intervention they tool-loop forever
+and never emit ``stop_reason=end_turn``.
+
+Design goal: completely transparent for strong models (auto-bypass via model id
+pattern). For weak models, structurally constrain the agent loop so it cannot
+run away overnight.
+"""
+
+from __future__ import annotations
+
+from .config import GovernorConfig, load_governor_config
+from .governor import AgentGovernor, GovernorAction, Verdict
+
+__all__ = [
+    "AgentGovernor",
+    "GovernorAction",
+    "GovernorConfig",
+    "Verdict",
+    "load_governor_config",
+]

--- a/api/agent_governor/config.py
+++ b/api/agent_governor/config.py
@@ -1,0 +1,209 @@
+"""Environment-driven configuration for the agent governor."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+
+
+_DEFAULT_WEAK_PATTERNS = (
+    "qwen",
+    "nemotron",
+    "deepseek-chat",
+    "deepseek-coder",
+    "kimi",
+    "moonshot",
+    "gpt-oss",
+    "glm",
+    "mistral",
+    "llama",
+    "wafer",
+    "ring",
+    "minimax",
+    "gemma",
+    "hermes",
+    "command",
+    "yi-",
+)
+_DEFAULT_STRONG_PATTERNS = (
+    "claude-",
+    "gpt-5",
+    "gpt-4",
+    "o1-",
+    "o3-",
+    "o4-",
+    "grok-",
+    "gemini-",
+)
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning(
+            "Invalid {} value: {!r} — using default {}", name, raw, default
+        )
+        return default
+
+
+def _csv_env(name: str, default: tuple[str, ...]) -> tuple[str, ...]:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    return tuple(item.strip().lower() for item in raw.split(",") if item.strip())
+
+
+def _json_env(name: str) -> dict[str, Any]:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "Invalid {} JSON: {} — ignoring overrides", name, exc.msg
+        )
+        return {}
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "{} must decode to a JSON object — ignoring overrides", name
+        )
+        return {}
+    return parsed
+
+
+@dataclass(slots=True)
+class ModelOverride:
+    """Per-model configuration override (subset of GovernorConfig)."""
+
+    enabled: bool | None = None
+    tool_cull_enabled: bool | None = None
+    tool_cull_max: int | None = None
+    max_consecutive_tool_calls: int | None = None
+    max_total_tool_calls: int | None = None
+    loop_repeat_threshold: int | None = None
+    plan_mode: bool | None = None
+    termination_hint: bool | None = None
+
+
+@dataclass(slots=True)
+class GovernorConfig:
+    """Resolved governor configuration for one request."""
+
+    enabled: bool = True
+    tool_cull_enabled: bool = True
+    tool_cull_max: int = 25
+    max_consecutive_tool_calls: int = 8
+    max_total_tool_calls: int = 40
+    loop_repeat_threshold: int = 3
+    plan_mode_for_weak: bool = True
+    termination_hint_for_weak: bool = True
+    weak_model_patterns: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_WEAK_PATTERNS)
+    strong_model_patterns: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_STRONG_PATTERNS)
+    overrides: dict[str, ModelOverride] = field(default_factory=dict)
+
+    def is_strong_model(self, model_id: str) -> bool:
+        lowered = model_id.lower()
+        return any(pat in lowered for pat in self.strong_model_patterns)
+
+    def is_weak_model(self, model_id: str) -> bool:
+        lowered = model_id.lower()
+        return any(pat in lowered for pat in self.weak_model_patterns)
+
+    def for_model(self, model_id: str) -> GovernorConfig:
+        """Return effective config after applying per-model overrides."""
+        override = self.overrides.get(model_id) or self.overrides.get(
+            self._best_override_key(model_id)
+        )
+        if override is None:
+            return self
+        return GovernorConfig(
+            enabled=override.enabled if override.enabled is not None else self.enabled,
+            tool_cull_enabled=override.tool_cull_enabled
+            if override.tool_cull_enabled is not None
+            else self.tool_cull_enabled,
+            tool_cull_max=override.tool_cull_max
+            if override.tool_cull_max is not None
+            else self.tool_cull_max,
+            max_consecutive_tool_calls=override.max_consecutive_tool_calls
+            if override.max_consecutive_tool_calls is not None
+            else self.max_consecutive_tool_calls,
+            max_total_tool_calls=override.max_total_tool_calls
+            if override.max_total_tool_calls is not None
+            else self.max_total_tool_calls,
+            loop_repeat_threshold=override.loop_repeat_threshold
+            if override.loop_repeat_threshold is not None
+            else self.loop_repeat_threshold,
+            plan_mode_for_weak=override.plan_mode
+            if override.plan_mode is not None
+            else self.plan_mode_for_weak,
+            termination_hint_for_weak=override.termination_hint
+            if override.termination_hint is not None
+            else self.termination_hint_for_weak,
+            weak_model_patterns=self.weak_model_patterns,
+            strong_model_patterns=self.strong_model_patterns,
+            overrides=self.overrides,
+        )
+
+    def _best_override_key(self, model_id: str) -> str | None:
+        """Find the longest configured key that is a substring of model_id."""
+        candidates = [k for k in self.overrides if k and k in model_id]
+        if not candidates:
+            return None
+        return max(candidates, key=len)
+
+
+def load_governor_config() -> GovernorConfig:
+    """Build a GovernorConfig from environment variables (process-level)."""
+    cfg = GovernorConfig(
+        enabled=_bool_env("GOVERNOR_ENABLED", True),
+        tool_cull_enabled=_bool_env("GOVERNOR_TOOL_CULL_ENABLED", True),
+        tool_cull_max=_int_env("GOVERNOR_TOOL_CULL_MAX", 25),
+        max_consecutive_tool_calls=_int_env(
+            "GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS", 8
+        ),
+        max_total_tool_calls=_int_env("GOVERNOR_MAX_TOTAL_TOOL_CALLS", 40),
+        loop_repeat_threshold=_int_env("GOVERNOR_LOOP_REPEAT_THRESHOLD", 3),
+        plan_mode_for_weak=_bool_env("GOVERNOR_PLAN_MODE_FOR_WEAK", True),
+        termination_hint_for_weak=_bool_env(
+            "GOVERNOR_TERMINATION_HINT_FOR_WEAK", True
+        ),
+        weak_model_patterns=_csv_env(
+            "GOVERNOR_WEAK_MODEL_PATTERNS", _DEFAULT_WEAK_PATTERNS
+        ),
+        strong_model_patterns=_csv_env(
+            "GOVERNOR_STRONG_MODEL_PATTERNS", _DEFAULT_STRONG_PATTERNS
+        ),
+    )
+    overrides_raw = _json_env("GOVERNOR_OVERRIDES_JSON")
+    overrides: dict[str, ModelOverride] = {}
+    for model_id, payload in overrides_raw.items():
+        if not isinstance(model_id, str) or not isinstance(payload, dict):
+            continue
+        overrides[model_id] = ModelOverride(
+            enabled=payload.get("enabled"),
+            tool_cull_enabled=payload.get("tool_cull_enabled"),
+            tool_cull_max=payload.get("tool_cull_max"),
+            max_consecutive_tool_calls=payload.get("max_consecutive_tool_calls"),
+            max_total_tool_calls=payload.get("max_total_tool_calls"),
+            loop_repeat_threshold=payload.get("loop_repeat_threshold"),
+            plan_mode=payload.get("plan_mode"),
+            termination_hint=payload.get("termination_hint"),
+        )
+    cfg.overrides = overrides
+    return cfg

--- a/api/agent_governor/config.py
+++ b/api/agent_governor/config.py
@@ -1,4 +1,17 @@
-"""Environment-driven configuration for the agent governor."""
+"""Environment-driven configuration for the agent governor.
+
+Cap fields are ``int | None``: ``None`` means "delegate to the tier defaults
+for the model in question". ``load_governor_config()`` populates them from
+env (when set) or leaves them ``None`` so that :meth:`GovernorConfig.for_model`
+can fall back to size-tier defaults.
+
+Resolution order (highest precedence → lowest):
+  1. Per-model override (``GOVERNOR_OVERRIDES_JSON``)
+  2. Process-level env value (e.g. ``GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS``)
+  3. Tier defaults (from :mod:`api.agent_governor.tiers`,
+     overridable via ``GOVERNOR_TIER_CAPS_JSON``)
+  4. Hardcoded fallback if everything else is missing
+"""
 
 from __future__ import annotations
 
@@ -9,12 +22,21 @@ from typing import Any
 
 from loguru import logger
 
+from .tiers import (
+    TIER_DEFAULTS,
+    ModelTier,
+    TierCaps,
+    caps_for_tier,
+    detect_tier,
+)
+
 
 _DEFAULT_WEAK_PATTERNS = (
     "qwen",
     "nemotron",
     "deepseek-chat",
     "deepseek-coder",
+    "deepseek-v",
     "kimi",
     "moonshot",
     "gpt-oss",
@@ -41,14 +63,14 @@ _DEFAULT_STRONG_PATTERNS = (
 )
 
 
-def _bool_env(name: str, default: bool) -> bool:
+def _bool_env(name: str, default: bool | None) -> bool | None:
     raw = os.environ.get(name, "").strip().lower()
     if not raw:
         return default
     return raw in ("1", "true", "yes", "on")
 
 
-def _int_env(name: str, default: int) -> int:
+def _int_env(name: str, default: int | None) -> int | None:
     raw = os.environ.get(name, "").strip()
     if not raw:
         return default
@@ -99,23 +121,37 @@ class ModelOverride:
     loop_repeat_threshold: int | None = None
     plan_mode: bool | None = None
     termination_hint: bool | None = None
+    tier: ModelTier | None = None  # force a specific tier for this model
 
 
 @dataclass(slots=True)
 class GovernorConfig:
-    """Resolved governor configuration for one request."""
+    """Resolved governor configuration for one request.
+
+    When :meth:`for_model` runs, this returns a new instance with all
+    Optional cap fields filled in from tier defaults / env / overrides.
+    The "process-level" instance (loaded from env) may carry ``None``
+    values; the "per-model" instance never does.
+    """
 
     enabled: bool = True
     tool_cull_enabled: bool = True
-    tool_cull_max: int = 25
-    max_consecutive_tool_calls: int = 8
-    max_total_tool_calls: int = 40
+    tool_cull_max: int | None = None
+    max_consecutive_tool_calls: int | None = None
+    max_total_tool_calls: int | None = None
     loop_repeat_threshold: int = 3
-    plan_mode_for_weak: bool = True
-    termination_hint_for_weak: bool = True
-    weak_model_patterns: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_WEAK_PATTERNS)
-    strong_model_patterns: tuple[str, ...] = field(default_factory=lambda: _DEFAULT_STRONG_PATTERNS)
+    plan_mode_for_weak: bool | None = None
+    termination_hint_for_weak: bool | None = None
+    weak_model_patterns: tuple[str, ...] = field(
+        default_factory=lambda: _DEFAULT_WEAK_PATTERNS
+    )
+    strong_model_patterns: tuple[str, ...] = field(
+        default_factory=lambda: _DEFAULT_STRONG_PATTERNS
+    )
     overrides: dict[str, ModelOverride] = field(default_factory=dict)
+    tier_caps: dict[ModelTier, TierCaps] = field(
+        default_factory=lambda: dict(TIER_DEFAULTS)
+    )
 
     def is_strong_model(self, model_id: str) -> bool:
         lowered = model_id.lower()
@@ -125,40 +161,85 @@ class GovernorConfig:
         lowered = model_id.lower()
         return any(pat in lowered for pat in self.weak_model_patterns)
 
+    def tier_for(self, model_id: str) -> ModelTier:
+        """Return the size tier this config will use for ``model_id``."""
+        if self.is_strong_model(model_id):
+            return ModelTier.FRONTIER
+        # Per-model override may pin a tier explicitly.
+        override = self._lookup_override(model_id)
+        if override and override.tier is not None:
+            return override.tier
+        return detect_tier(model_id)
+
     def for_model(self, model_id: str) -> GovernorConfig:
-        """Return effective config after applying per-model overrides."""
-        override = self.overrides.get(model_id) or self.overrides.get(
-            self._best_override_key(model_id)
-        )
-        if override is None:
-            return self
+        """Return effective config for one model with all caps resolved."""
+        override = self._lookup_override(model_id)
+        tier = self.tier_for(model_id)
+        tier_caps = self.tier_caps.get(tier) or caps_for_tier(tier)
+
+        def resolve_int(*candidates: int | None) -> int:
+            for value in candidates:
+                if value is not None:
+                    return value
+            return 0
+
+        def resolve_bool(*candidates: bool | None) -> bool:
+            for value in candidates:
+                if value is not None:
+                    return value
+            return False
+
+        ovr = override
         return GovernorConfig(
-            enabled=override.enabled if override.enabled is not None else self.enabled,
-            tool_cull_enabled=override.tool_cull_enabled
-            if override.tool_cull_enabled is not None
-            else self.tool_cull_enabled,
-            tool_cull_max=override.tool_cull_max
-            if override.tool_cull_max is not None
-            else self.tool_cull_max,
-            max_consecutive_tool_calls=override.max_consecutive_tool_calls
-            if override.max_consecutive_tool_calls is not None
-            else self.max_consecutive_tool_calls,
-            max_total_tool_calls=override.max_total_tool_calls
-            if override.max_total_tool_calls is not None
-            else self.max_total_tool_calls,
-            loop_repeat_threshold=override.loop_repeat_threshold
-            if override.loop_repeat_threshold is not None
+            enabled=resolve_bool(
+                ovr.enabled if ovr else None, self.enabled, True
+            ),
+            tool_cull_enabled=resolve_bool(
+                ovr.tool_cull_enabled if ovr else None,
+                self.tool_cull_enabled,
+                True,
+            ),
+            tool_cull_max=resolve_int(
+                ovr.tool_cull_max if ovr else None,
+                self.tool_cull_max,
+                tier_caps.tool_cull_max,
+            ),
+            max_consecutive_tool_calls=resolve_int(
+                ovr.max_consecutive_tool_calls if ovr else None,
+                self.max_consecutive_tool_calls,
+                tier_caps.max_consecutive_tool_calls,
+            ),
+            max_total_tool_calls=resolve_int(
+                ovr.max_total_tool_calls if ovr else None,
+                self.max_total_tool_calls,
+                tier_caps.max_total_tool_calls,
+            ),
+            loop_repeat_threshold=ovr.loop_repeat_threshold
+            if ovr and ovr.loop_repeat_threshold is not None
             else self.loop_repeat_threshold,
-            plan_mode_for_weak=override.plan_mode
-            if override.plan_mode is not None
-            else self.plan_mode_for_weak,
-            termination_hint_for_weak=override.termination_hint
-            if override.termination_hint is not None
-            else self.termination_hint_for_weak,
+            plan_mode_for_weak=resolve_bool(
+                ovr.plan_mode if ovr else None,
+                self.plan_mode_for_weak,
+                tier_caps.plan_mode,
+            ),
+            termination_hint_for_weak=resolve_bool(
+                ovr.termination_hint if ovr else None,
+                self.termination_hint_for_weak,
+                tier_caps.termination_hint,
+            ),
             weak_model_patterns=self.weak_model_patterns,
             strong_model_patterns=self.strong_model_patterns,
             overrides=self.overrides,
+            tier_caps=self.tier_caps,
         )
+
+    def _lookup_override(self, model_id: str) -> ModelOverride | None:
+        if not self.overrides:
+            return None
+        if model_id in self.overrides:
+            return self.overrides[model_id]
+        best_key = self._best_override_key(model_id)
+        return self.overrides.get(best_key) if best_key else None
 
     def _best_override_key(self, model_id: str) -> str | None:
         """Find the longest configured key that is a substring of model_id."""
@@ -168,20 +249,53 @@ class GovernorConfig:
         return max(candidates, key=len)
 
 
+def _parse_tier_caps_overrides(raw: dict[str, Any]) -> dict[ModelTier, TierCaps]:
+    """Apply env-supplied per-tier overrides on top of TIER_DEFAULTS."""
+    merged: dict[ModelTier, TierCaps] = dict(TIER_DEFAULTS)
+    for tier_name, payload in raw.items():
+        if not isinstance(tier_name, str) or not isinstance(payload, dict):
+            continue
+        try:
+            tier = ModelTier(tier_name.lower())
+        except ValueError:
+            logger.warning(
+                "Unknown tier {!r} in GOVERNOR_TIER_CAPS_JSON — skipping",
+                tier_name,
+            )
+            continue
+        base = merged.get(tier, TIER_DEFAULTS[ModelTier.UNKNOWN])
+        merged[tier] = TierCaps(
+            max_consecutive_tool_calls=int(
+                payload.get("max_consecutive_tool_calls", base.max_consecutive_tool_calls)
+            ),
+            max_total_tool_calls=int(
+                payload.get("max_total_tool_calls", base.max_total_tool_calls)
+            ),
+            tool_cull_max=int(
+                payload.get("tool_cull_max", base.tool_cull_max)
+            ),
+            plan_mode=bool(payload.get("plan_mode", base.plan_mode)),
+            termination_hint=bool(
+                payload.get("termination_hint", base.termination_hint)
+            ),
+        )
+    return merged
+
+
 def load_governor_config() -> GovernorConfig:
     """Build a GovernorConfig from environment variables (process-level)."""
     cfg = GovernorConfig(
-        enabled=_bool_env("GOVERNOR_ENABLED", True),
-        tool_cull_enabled=_bool_env("GOVERNOR_TOOL_CULL_ENABLED", True),
-        tool_cull_max=_int_env("GOVERNOR_TOOL_CULL_MAX", 25),
+        enabled=_bool_env("GOVERNOR_ENABLED", True) or False,
+        tool_cull_enabled=_bool_env("GOVERNOR_TOOL_CULL_ENABLED", True) or False,
+        tool_cull_max=_int_env("GOVERNOR_TOOL_CULL_MAX", None),
         max_consecutive_tool_calls=_int_env(
-            "GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS", 8
+            "GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS", None
         ),
-        max_total_tool_calls=_int_env("GOVERNOR_MAX_TOTAL_TOOL_CALLS", 40),
-        loop_repeat_threshold=_int_env("GOVERNOR_LOOP_REPEAT_THRESHOLD", 3),
-        plan_mode_for_weak=_bool_env("GOVERNOR_PLAN_MODE_FOR_WEAK", True),
+        max_total_tool_calls=_int_env("GOVERNOR_MAX_TOTAL_TOOL_CALLS", None),
+        loop_repeat_threshold=_int_env("GOVERNOR_LOOP_REPEAT_THRESHOLD", 3) or 3,
+        plan_mode_for_weak=_bool_env("GOVERNOR_PLAN_MODE_FOR_WEAK", None),
         termination_hint_for_weak=_bool_env(
-            "GOVERNOR_TERMINATION_HINT_FOR_WEAK", True
+            "GOVERNOR_TERMINATION_HINT_FOR_WEAK", None
         ),
         weak_model_patterns=_csv_env(
             "GOVERNOR_WEAK_MODEL_PATTERNS", _DEFAULT_WEAK_PATTERNS
@@ -190,11 +304,28 @@ def load_governor_config() -> GovernorConfig:
             "GOVERNOR_STRONG_MODEL_PATTERNS", _DEFAULT_STRONG_PATTERNS
         ),
     )
+    cfg.tier_caps = _parse_tier_caps_overrides(
+        _json_env("GOVERNOR_TIER_CAPS_JSON")
+    )
     overrides_raw = _json_env("GOVERNOR_OVERRIDES_JSON")
     overrides: dict[str, ModelOverride] = {}
     for model_id, payload in overrides_raw.items():
         if not isinstance(model_id, str) or not isinstance(payload, dict):
             continue
+        tier_value = payload.get("tier")
+        tier_enum: ModelTier | None
+        if isinstance(tier_value, str):
+            try:
+                tier_enum = ModelTier(tier_value.lower())
+            except ValueError:
+                logger.warning(
+                    "Unknown tier {!r} in GOVERNOR_OVERRIDES_JSON for {!r}",
+                    tier_value,
+                    model_id,
+                )
+                tier_enum = None
+        else:
+            tier_enum = None
         overrides[model_id] = ModelOverride(
             enabled=payload.get("enabled"),
             tool_cull_enabled=payload.get("tool_cull_enabled"),
@@ -204,6 +335,7 @@ def load_governor_config() -> GovernorConfig:
             loop_repeat_threshold=payload.get("loop_repeat_threshold"),
             plan_mode=payload.get("plan_mode"),
             termination_hint=payload.get("termination_hint"),
+            tier=tier_enum,
         )
     cfg.overrides = overrides
     return cfg

--- a/api/agent_governor/conversation_stats.py
+++ b/api/agent_governor/conversation_stats.py
@@ -1,0 +1,110 @@
+"""Pure helpers for inspecting conversation history."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+
+@dataclass(slots=True)
+class ToolCallRef:
+    """Lightweight reference to a single tool_use block."""
+
+    name: str
+    args_hash: str
+
+
+@dataclass(slots=True)
+class ConversationStats:
+    """Summary of tool-call patterns in a conversation."""
+
+    total_messages: int = 0
+    total_tool_calls: int = 0
+    consecutive_tool_calls: int = 0
+    recent_tool_calls: list[ToolCallRef] = field(default_factory=list)
+    last_assistant_text_len: int = 0
+
+
+def _iter_content_blocks(message: Any) -> Iterable[Any]:
+    """Yield content blocks from a Message; tolerate str-content."""
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        yield from content
+
+
+def _hash_args(args: Any) -> str:
+    """Stable short hash of tool arguments for loop detection."""
+    try:
+        canonical = json.dumps(args, sort_keys=True, default=str)
+    except Exception:
+        canonical = repr(args)
+    return hashlib.sha1(canonical.encode("utf-8", errors="replace")).hexdigest()[:12]
+
+
+def compute_stats(messages: list[Any], *, recent_window: int = 8) -> ConversationStats:
+    """Walk messages, count tool_use blocks, capture recent tool signatures.
+
+    Counts:
+    * ``total_tool_calls``: every tool_use block across the full history.
+    * ``consecutive_tool_calls``: tool_use blocks at the tail without an
+      intervening assistant text-only turn or fresh user message.
+    * ``recent_tool_calls``: last ``recent_window`` (name, args_hash) pairs,
+      newest last — used by the loop detector.
+    * ``last_assistant_text_len``: chars of text in the most recent assistant
+      message (zero if none, or if it was tool-only). Useful proxy for whether
+      the model has produced a real answer recently.
+    """
+    stats = ConversationStats(total_messages=len(messages))
+    consecutive_streak = 0
+    recent: list[ToolCallRef] = []
+    last_text_len = 0
+    last_assistant_seen = False
+
+    for message in messages:
+        role = getattr(message, "role", None)
+        tool_uses_in_message: list[ToolCallRef] = []
+        tool_results_in_message = 0
+        text_chars = 0
+        for block in _iter_content_blocks(message):
+            block_type = getattr(block, "type", None)
+            if block_type == "tool_use":
+                ref = ToolCallRef(
+                    name=getattr(block, "name", "?") or "?",
+                    args_hash=_hash_args(getattr(block, "input", {})),
+                )
+                tool_uses_in_message.append(ref)
+            elif block_type == "tool_result":
+                tool_results_in_message += 1
+            elif block_type == "text":
+                text_value = getattr(block, "text", "") or ""
+                text_chars += len(text_value)
+
+        stats.total_tool_calls += len(tool_uses_in_message)
+        recent.extend(tool_uses_in_message)
+
+        if role == "assistant":
+            last_assistant_seen = True
+            last_text_len = text_chars
+            if tool_uses_in_message:
+                # Continue or start a streak. Whether it was broken before is
+                # irrelevant; we count the trailing run.
+                consecutive_streak += len(tool_uses_in_message)
+            else:
+                # assistant text-only turn ends the trailing run.
+                consecutive_streak = 0
+        elif role == "user":
+            # Pure tool_result turns are part of the agent loop.
+            # Anything else (real user text, mixed content, image, etc.)
+            # is a fresh user turn that resets the streak.
+            has_only_tool_results = (
+                tool_results_in_message > 0 and text_chars == 0
+            )
+            if not has_only_tool_results:
+                consecutive_streak = 0
+
+    stats.consecutive_tool_calls = consecutive_streak
+    stats.recent_tool_calls = recent[-recent_window:]
+    stats.last_assistant_text_len = last_text_len if last_assistant_seen else 0
+    return stats

--- a/api/agent_governor/governor.py
+++ b/api/agent_governor/governor.py
@@ -1,0 +1,254 @@
+"""Main governor orchestrator.
+
+The governor is invoked from ``api/services.py`` once per ``/v1/messages``
+request, after context-trim and before provider streaming. It returns a
+:class:`Verdict` describing what the proxy should do next:
+
+* ``pass``    — forward the (possibly augmented) request to the provider.
+* ``augment`` — same, but the request was modified (system, tools, messages).
+* ``abort``   — short-circuit with a forced text response.
+
+The governor itself is stateless. All decisions are derived from the request's
+own message history; Claude Code re-sends the full conversation each turn.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+from api.models.anthropic import MessagesRequest
+from api.models.responses import MessagesResponse, Usage
+
+from .config import GovernorConfig, load_governor_config
+from .conversation_stats import ConversationStats, compute_stats
+from .loop_detect import detect_repeated_signature
+from .system_augmentation import with_plan_mode, with_termination_hint
+from .telemetry import log_decision, log_skipped
+from .tool_cull import CullResult, apply_cull, cull_tools
+
+
+class GovernorAction(StrEnum):
+    PASS = "pass"
+    AUGMENT = "augment"
+    ABORT = "abort"
+
+
+@dataclass(slots=True)
+class Verdict:
+    """Outcome of one governor review."""
+
+    action: GovernorAction
+    augmented_request: MessagesRequest | None = None
+    short_circuit_response: MessagesResponse | None = None
+    interventions: tuple[str, ...] = field(default_factory=tuple)
+
+
+class AgentGovernor:
+    """Run the configured interventions against one request."""
+
+    def __init__(
+        self,
+        config: GovernorConfig | None = None,
+    ):
+        self._config = config or load_governor_config()
+
+    @property
+    def config(self) -> GovernorConfig:
+        return self._config
+
+    def review(
+        self,
+        request: MessagesRequest,
+        *,
+        request_id: str,
+        provider_id: str,
+    ) -> Verdict:
+        """Inspect a request, decide on an intervention, return a Verdict."""
+        cfg = self._config.for_model(request.model)
+
+        if not cfg.enabled:
+            log_skipped(request_id, request.model, "disabled")
+            return Verdict(action=GovernorAction.PASS)
+
+        if cfg.is_strong_model(request.model):
+            log_skipped(request_id, request.model, "strong_model_bypass")
+            return Verdict(action=GovernorAction.PASS)
+
+        is_weak = cfg.is_weak_model(request.model)
+        stats = compute_stats(request.messages)
+        tools_in_request = len(request.tools or [])
+
+        # ---- 1. Hard abort: total tool budget exceeded
+        if (
+            cfg.max_total_tool_calls > 0
+            and stats.total_tool_calls >= cfg.max_total_tool_calls
+        ):
+            response = self._build_abort_response(
+                request,
+                reason="total_tool_budget_exceeded",
+                detail=(
+                    f"This conversation has used {stats.total_tool_calls} tool "
+                    f"calls, exceeding the configured budget of "
+                    f"{cfg.max_total_tool_calls}. Stopping to prevent runaway "
+                    f"loops. Start a fresh session to continue, ideally with a "
+                    f"narrower task and fewer tools loaded."
+                ),
+            )
+            log_decision(
+                request_id,
+                request.model,
+                action=GovernorAction.ABORT,
+                consecutive_tool_calls=stats.consecutive_tool_calls,
+                total_tool_calls=stats.total_tool_calls,
+                tools_in_request=tools_in_request,
+                reason="total_tool_budget_exceeded",
+            )
+            return Verdict(
+                action=GovernorAction.ABORT,
+                short_circuit_response=response,
+                interventions=("total_budget_abort",),
+            )
+
+        # ---- 2. Hard abort: detected repeating tool+args signature
+        repeat = detect_repeated_signature(
+            stats, threshold=cfg.loop_repeat_threshold
+        )
+        if repeat is not None:
+            response = self._build_abort_response(
+                request,
+                reason="loop_signature_detected",
+                detail=(
+                    f"Detected {cfg.loop_repeat_threshold}+ identical calls to "
+                    f"'{repeat.name}' with the same arguments in the recent "
+                    f"history. The result is not changing — stopping the loop. "
+                    f"Try a different approach or report what you found so far."
+                ),
+            )
+            log_decision(
+                request_id,
+                request.model,
+                action=GovernorAction.ABORT,
+                consecutive_tool_calls=stats.consecutive_tool_calls,
+                total_tool_calls=stats.total_tool_calls,
+                tools_in_request=tools_in_request,
+                intervention="loop_signature",
+                reason=f"repeat:{repeat.name}",
+            )
+            return Verdict(
+                action=GovernorAction.ABORT,
+                short_circuit_response=response,
+                interventions=("loop_signature_abort",),
+            )
+
+        # ---- 3. Soft abort: too many consecutive tool calls without text
+        if (
+            cfg.max_consecutive_tool_calls > 0
+            and stats.consecutive_tool_calls >= cfg.max_consecutive_tool_calls
+        ):
+            response = self._build_abort_response(
+                request,
+                reason="consecutive_tool_calls_exceeded",
+                detail=(
+                    f"You have made {stats.consecutive_tool_calls} consecutive "
+                    f"tool calls without producing a text answer. Stop now and "
+                    f"summarise what you've found, or state clearly that you "
+                    f"cannot complete the task. Pause, review, and answer."
+                ),
+            )
+            log_decision(
+                request_id,
+                request.model,
+                action=GovernorAction.ABORT,
+                consecutive_tool_calls=stats.consecutive_tool_calls,
+                total_tool_calls=stats.total_tool_calls,
+                tools_in_request=tools_in_request,
+                intervention="consecutive_tools",
+                reason="cap_reached",
+            )
+            return Verdict(
+                action=GovernorAction.ABORT,
+                short_circuit_response=response,
+                interventions=("consecutive_tools_abort",),
+            )
+
+        # ---- 4. Augment: tool culling, plan mode, termination hint
+        augmented = request
+        interventions: list[str] = []
+        cull_outcome: CullResult | None = None
+
+        if (
+            cfg.tool_cull_enabled
+            and request.tools
+            and len(request.tools) > cfg.tool_cull_max
+        ):
+            cull_outcome = cull_tools(
+                request.tools,
+                request.messages,
+                request.system,
+                max_keep=cfg.tool_cull_max,
+            )
+            if cull_outcome.dropped_count > 0:
+                new_tools = apply_cull(request.tools, cull_outcome)
+                augmented = augmented.model_copy(update={"tools": new_tools})
+                interventions.append(f"tool_cull(-{cull_outcome.dropped_count})")
+
+        if is_weak and cfg.plan_mode_for_weak:
+            new_system = with_plan_mode(augmented.system)
+            if new_system is not augmented.system:
+                augmented = augmented.model_copy(update={"system": new_system})
+                interventions.append("plan_mode")
+
+        if is_weak and cfg.termination_hint_for_weak:
+            new_system = with_termination_hint(augmented.system)
+            if new_system is not augmented.system:
+                augmented = augmented.model_copy(update={"system": new_system})
+                interventions.append("termination_hint")
+
+        if not interventions:
+            log_decision(
+                request_id,
+                request.model,
+                action=GovernorAction.PASS,
+                consecutive_tool_calls=stats.consecutive_tool_calls,
+                total_tool_calls=stats.total_tool_calls,
+                tools_in_request=tools_in_request,
+            )
+            return Verdict(action=GovernorAction.PASS)
+
+        log_decision(
+            request_id,
+            request.model,
+            action=GovernorAction.AUGMENT,
+            consecutive_tool_calls=stats.consecutive_tool_calls,
+            total_tool_calls=stats.total_tool_calls,
+            tools_in_request=tools_in_request,
+            tools_after_cull=len(augmented.tools or []) if cull_outcome else None,
+            intervention=",".join(interventions),
+        )
+        return Verdict(
+            action=GovernorAction.AUGMENT,
+            augmented_request=augmented,
+            interventions=tuple(interventions),
+        )
+
+    @staticmethod
+    def _build_abort_response(
+        request: MessagesRequest, *, reason: str, detail: str
+    ) -> MessagesResponse:
+        """Return an Anthropic-shape response that ends the conversation cleanly."""
+        text = (
+            f"[agent governor: {reason}]\n\n{detail}"
+        )
+        return MessagesResponse(
+            id=f"msg_{uuid.uuid4().hex}",
+            model=request.model,
+            content=[{"type": "text", "text": text}],
+            stop_reason="end_turn",
+            usage=Usage(input_tokens=0, output_tokens=len(text) // 4),
+        )
+
+
+__all__ = ["AgentGovernor", "GovernorAction", "Verdict"]

--- a/api/agent_governor/governor.py
+++ b/api/agent_governor/governor.py
@@ -27,6 +27,7 @@ from .conversation_stats import ConversationStats, compute_stats
 from .loop_detect import detect_repeated_signature
 from .system_augmentation import with_plan_mode, with_termination_hint
 from .telemetry import log_decision, log_skipped
+from .tiers import ModelTier
 from .tool_cull import CullResult, apply_cull, cull_tools
 
 
@@ -67,17 +68,21 @@ class AgentGovernor:
         provider_id: str,
     ) -> Verdict:
         """Inspect a request, decide on an intervention, return a Verdict."""
+        tier = self._config.tier_for(request.model)
         cfg = self._config.for_model(request.model)
 
         if not cfg.enabled:
             log_skipped(request_id, request.model, "disabled")
             return Verdict(action=GovernorAction.PASS)
 
-        if cfg.is_strong_model(request.model):
+        if tier == ModelTier.FRONTIER:
             log_skipped(request_id, request.model, "strong_model_bypass")
             return Verdict(action=GovernorAction.PASS)
 
-        is_weak = cfg.is_weak_model(request.model)
+        # Any non-frontier model gets the augmentation pipeline. Tier defaults
+        # already decided whether plan_mode / termination_hint are appropriate
+        # for the size class, so we just respect cfg.{plan_mode,termination_hint}_for_weak.
+        is_weak = True
         stats = compute_stats(request.messages)
         tools_in_request = len(request.tools or [])
 
@@ -105,6 +110,7 @@ class AgentGovernor:
                 total_tool_calls=stats.total_tool_calls,
                 tools_in_request=tools_in_request,
                 reason="total_tool_budget_exceeded",
+                extra={"tier": tier.value},
             )
             return Verdict(
                 action=GovernorAction.ABORT,
@@ -136,6 +142,7 @@ class AgentGovernor:
                 tools_in_request=tools_in_request,
                 intervention="loop_signature",
                 reason=f"repeat:{repeat.name}",
+                extra={"tier": tier.value},
             )
             return Verdict(
                 action=GovernorAction.ABORT,
@@ -167,6 +174,7 @@ class AgentGovernor:
                 tools_in_request=tools_in_request,
                 intervention="consecutive_tools",
                 reason="cap_reached",
+                extra={"tier": tier.value},
             )
             return Verdict(
                 action=GovernorAction.ABORT,
@@ -215,6 +223,7 @@ class AgentGovernor:
                 consecutive_tool_calls=stats.consecutive_tool_calls,
                 total_tool_calls=stats.total_tool_calls,
                 tools_in_request=tools_in_request,
+                extra={"tier": tier.value},
             )
             return Verdict(action=GovernorAction.PASS)
 
@@ -227,6 +236,7 @@ class AgentGovernor:
             tools_in_request=tools_in_request,
             tools_after_cull=len(augmented.tools or []) if cull_outcome else None,
             intervention=",".join(interventions),
+            extra={"tier": tier.value},
         )
         return Verdict(
             action=GovernorAction.AUGMENT,

--- a/api/agent_governor/loop_detect.py
+++ b/api/agent_governor/loop_detect.py
@@ -1,0 +1,20 @@
+"""Detect repeated tool calls (same tool + same args) in a conversation tail."""
+
+from __future__ import annotations
+
+from .conversation_stats import ConversationStats, ToolCallRef
+
+
+def detect_repeated_signature(
+    stats: ConversationStats, *, threshold: int
+) -> ToolCallRef | None:
+    """Return the ToolCallRef seen ``threshold``+ times in recent_tool_calls."""
+    if threshold <= 1 or not stats.recent_tool_calls:
+        return None
+    counts: dict[tuple[str, str], int] = {}
+    for ref in stats.recent_tool_calls:
+        key = (ref.name, ref.args_hash)
+        counts[key] = counts.get(key, 0) + 1
+        if counts[key] >= threshold:
+            return ref
+    return None

--- a/api/agent_governor/system_augmentation.py
+++ b/api/agent_governor/system_augmentation.py
@@ -1,0 +1,108 @@
+"""Append governor preambles to the system prompt for weak models.
+
+Two preambles, both opt-in via env:
+
+* **plan_mode** — instructs the model to write a 3-step plan before any tool
+  call. Acts as a soft termination signal: once the plan completes, the model
+  has license to stop.
+* **termination_hint** — explicitly tells the model that text-only output is a
+  valid answer; it does NOT need to call a tool to terminate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PLAN_MODE_PREAMBLE = """\
+[Operating mode: plan-then-execute]
+
+Before calling any tool, write a numbered plan with at most 5 short steps. \
+Each step should be one sentence describing a single concrete action. After \
+the plan, execute the steps in order. After completing the plan, write a \
+final answer summarising what you found or did. Do not call additional tools \
+beyond the plan unless absolutely necessary."""
+
+
+TERMINATION_HINT_PREAMBLE = """\
+[Termination policy]
+
+When you have answered the user's question, completed the requested task, OR \
+when you cannot make further progress, output your final answer as plain \
+text and stop. Do not keep calling tools to "double-check" — one verification \
+is enough. If a tool returned an error or unhelpful result twice in a row, \
+state what you tried and stop. Tool calls are expensive; text answers are free."""
+
+
+def _coerce_system_to_string(system: Any) -> tuple[str, str]:
+    """Return (prefix_for_concatenation, marker_to_check_for) used by callers.
+
+    fcc preserves Anthropic's structured ``system`` field — it can be ``None``,
+    a plain string, or a list of SystemContent blocks. The governor stays
+    structure-preserving by editing or appending blocks, not by flattening.
+    Callers receive the original system unchanged from this helper; this exists
+    only for the existence-check below.
+    """
+    if isinstance(system, str):
+        return system, system
+    if isinstance(system, list):
+        joined = " ".join(
+            getattr(block, "text", "") or ""
+            for block in system
+            if hasattr(block, "text")
+        )
+        joined += " " + " ".join(
+            block.get("text", "") if isinstance(block, dict) else ""
+            for block in system
+        )
+        return joined, joined
+    return "", ""
+
+
+def _has_marker(system: Any, marker: str) -> bool:
+    _, joined = _coerce_system_to_string(system)
+    return marker in joined
+
+
+def with_plan_mode(system: Any) -> Any:
+    """Append the plan-mode preamble unless already present."""
+    return _append_preamble(system, PLAN_MODE_PREAMBLE, marker="[Operating mode: plan-then-execute]")
+
+
+def with_termination_hint(system: Any) -> Any:
+    """Append the termination-hint preamble unless already present."""
+    return _append_preamble(system, TERMINATION_HINT_PREAMBLE, marker="[Termination policy]")
+
+
+def _append_preamble(system: Any, preamble: str, *, marker: str) -> Any:
+    if _has_marker(system, marker):
+        return system
+    if system is None:
+        return preamble
+    if isinstance(system, str):
+        return system.rstrip() + "\n\n" + preamble
+    if isinstance(system, list):
+        # Append a new structured text block so we don't disturb cache_control
+        # or other attributes on existing blocks.
+        new_block = _build_text_block(system, preamble)
+        return list(system) + [new_block]
+    # Unknown shape — fall back to leaving system alone.
+    return system
+
+
+def _build_text_block(existing: list[Any], text: str) -> Any:
+    """Build a SystemContent-shaped block matching whatever the existing list uses.
+
+    Callers may pass pydantic models or dicts depending on origin. We mimic
+    whichever form is already present so the request remains serialisable.
+    """
+    for item in existing:
+        if hasattr(item, "model_copy"):
+            try:
+                clone = item.model_copy(update={"text": text})
+                return clone
+            except Exception:
+                continue
+        if isinstance(item, dict):
+            return {"type": item.get("type", "text"), "text": text}
+    return {"type": "text", "text": text}

--- a/api/agent_governor/telemetry.py
+++ b/api/agent_governor/telemetry.py
@@ -1,0 +1,51 @@
+"""Structured logging for governor decisions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+
+
+def log_decision(
+    request_id: str,
+    model: str,
+    action: str,
+    *,
+    consecutive_tool_calls: int,
+    total_tool_calls: int,
+    tools_in_request: int,
+    tools_after_cull: int | None = None,
+    intervention: str | None = None,
+    reason: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Emit a single GOVERNOR: log line with all decision metadata."""
+    parts = [
+        f"request_id={request_id}",
+        f"model={model}",
+        f"action={action}",
+        f"consecutive_tools={consecutive_tool_calls}",
+        f"total_tools={total_tool_calls}",
+        f"tools_in={tools_in_request}",
+    ]
+    if tools_after_cull is not None and tools_after_cull != tools_in_request:
+        parts.append(f"tools_after_cull={tools_after_cull}")
+    if intervention:
+        parts.append(f"intervention={intervention}")
+    if reason:
+        parts.append(f"reason={reason}")
+    if extra:
+        for key, value in extra.items():
+            parts.append(f"{key}={value}")
+    logger.info("GOVERNOR: " + " ".join(parts))
+
+
+def log_skipped(request_id: str, model: str, reason: str) -> None:
+    """Emit a single line when the governor skips intervention entirely."""
+    logger.debug(
+        "GOVERNOR: request_id={} model={} action=skip reason={}",
+        request_id,
+        model,
+        reason,
+    )

--- a/api/agent_governor/tiers.py
+++ b/api/agent_governor/tiers.py
@@ -1,0 +1,234 @@
+"""Model size tiers and per-tier governor cap defaults.
+
+Open-weight models span a huge size range (3B → 675B+). A single cap
+schedule cannot serve a 30B nano *and* a 480B coder. This module assigns
+each model id to a tier and supplies tier-appropriate caps.
+
+Tier classification is **substring pattern matching** against the model id.
+Patterns are tried from largest tier to smallest, first match wins. So a
+model named ``mistral-large-3-675b-instruct-2512`` is classified as ``xxl``
+because ``675b`` is matched before any smaller substring would be tried.
+
+Frontier (Claude, GPT-5, Gemini, Grok) is matched first via the same
+pattern lists used elsewhere in the governor — those models bypass entirely.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ModelTier(StrEnum):
+    """Coarse size class. Drives default caps and prompt augmentations."""
+
+    FRONTIER = "frontier"  # Claude / GPT-5 / Gemini / Grok — bypass
+    XXL = "xxl"  # 600B+: mistral-large-3-675b
+    XL = "xl"  # 400-600B: qwen3-coder-480b, llama-3.1-405b, hermes-3-405b
+    LARGE = "large"  # 200-400B: nemotron-ultra-253b, deepseek-v4-pro, qwen 235b
+    MEDIUM = "medium"  # 80-200B: nemotron-super-120b, gpt-oss-120b, glm-4.6
+    SMALL = "small"  # 30-80B: qwen3-next-80b, llama-70b, nemotron-49b, gpt-oss-20b
+    TINY = "tiny"  # ≤30B: nemotron-nano-30b, llama-8b, gemma-9b
+    UNKNOWN = "unknown"  # falls back to small defaults
+
+
+@dataclass(slots=True, frozen=True)
+class TierCaps:
+    """Per-tier governor caps. Shipped as defaults, fully env-overridable."""
+
+    max_consecutive_tool_calls: int
+    max_total_tool_calls: int
+    tool_cull_max: int
+    plan_mode: bool
+    termination_hint: bool
+
+
+# Defaults reflect the practical balance between "free model can finish a
+# real task" and "free model cannot loop overnight." Larger models get
+# wider headroom because they're better at terminating on their own.
+TIER_DEFAULTS: dict[ModelTier, TierCaps] = {
+    ModelTier.TINY: TierCaps(
+        max_consecutive_tool_calls=4,
+        max_total_tool_calls=20,
+        tool_cull_max=15,
+        plan_mode=True,
+        termination_hint=True,
+    ),
+    ModelTier.SMALL: TierCaps(
+        max_consecutive_tool_calls=8,
+        max_total_tool_calls=40,
+        tool_cull_max=25,
+        plan_mode=True,
+        termination_hint=True,
+    ),
+    ModelTier.MEDIUM: TierCaps(
+        max_consecutive_tool_calls=15,
+        max_total_tool_calls=80,
+        tool_cull_max=35,
+        plan_mode=True,
+        termination_hint=True,
+    ),
+    ModelTier.LARGE: TierCaps(
+        max_consecutive_tool_calls=25,
+        max_total_tool_calls=150,
+        tool_cull_max=50,
+        plan_mode=False,  # large coders plan well on their own
+        termination_hint=True,
+    ),
+    ModelTier.XL: TierCaps(
+        max_consecutive_tool_calls=40,
+        max_total_tool_calls=250,
+        tool_cull_max=60,
+        plan_mode=False,
+        termination_hint=True,
+    ),
+    ModelTier.XXL: TierCaps(
+        max_consecutive_tool_calls=60,
+        max_total_tool_calls=400,
+        tool_cull_max=80,
+        plan_mode=False,
+        termination_hint=False,  # 675B+ generally terminate themselves
+    ),
+    ModelTier.UNKNOWN: TierCaps(
+        max_consecutive_tool_calls=8,
+        max_total_tool_calls=40,
+        tool_cull_max=25,
+        plan_mode=True,
+        termination_hint=True,
+    ),
+}
+
+
+# Substring patterns for each tier, **ordered largest tier → smallest tier**.
+# First tier whose pattern list contains a substring of the (lowercased)
+# model id wins. Frontier check happens elsewhere; this map is for non-
+# frontier sizing only.
+#
+# Numeric size hints (``480b``, ``70b``) match the *total* parameter count
+# in conventional model naming. MoE active-params suffixes like ``a35b``
+# are intentionally NOT in the lists — we want total params, not active.
+TIER_PATTERNS: tuple[tuple[ModelTier, tuple[str, ...]], ...] = (
+    (
+        ModelTier.XXL,
+        (
+            "675b",
+            "qwen3-max",
+            "mistral-large-3",
+            "deepseek-r2",  # speculative; future-proof
+        ),
+    ),
+    (
+        ModelTier.XL,
+        (
+            "480b",
+            "405b",
+            "qwen3-coder-480b",
+            "llama-3.1-405b",
+            "hermes-3-llama-3.1-405b",
+            "ring-2.6-1t",  # 1T-param MoE; treat as XL not XXL since active params are smaller
+        ),
+    ),
+    (
+        ModelTier.LARGE,
+        (
+            "253b",
+            "235b",
+            "236b",
+            "230b",
+            "200b",
+            "ultra-253b",
+            "deepseek-v4-pro",
+            "deepseek-v4-flash",
+            "mistral-large-2",
+        ),
+    ),
+    (
+        ModelTier.MEDIUM,
+        (
+            "100b",
+            "120b",
+            "150b",
+            "180b",
+            "nemotron-super-120b",
+            "gpt-oss-120b",
+            "glm-4.6",
+            "glm-4.5",
+            "minimax-m2.5",
+            "kimi-k2",
+            "kimi-k2-instruct",
+            "mistral-nemotron",  # ~115B
+        ),
+    ),
+    (
+        ModelTier.SMALL,
+        (
+            "32b",
+            "40b",
+            "49b",
+            "60b",
+            "65b",
+            "70b",
+            "72b",
+            "78b",
+            "80b",
+            "qwen3-next-80b",
+            "qwen3-coder-30b",
+            "nemotron-3-super",  # safe even if numeric size missing
+            "llama-3.3-70b",
+            "llama-3.1-70b",
+            "command-r-plus",
+            "deepseek-coder-v2",
+        ),
+    ),
+    (
+        ModelTier.TINY,
+        (
+            "1b",
+            "2b",
+            "3b",
+            "4b",
+            "5b",
+            "6b",
+            "7b",
+            "8b",
+            "9b",
+            "12b",
+            "13b",
+            "14b",
+            "16b",
+            "20b",
+            "22b",
+            "24b",
+            "26b",
+            "28b",
+            "30b",
+            "nano-30b",
+            "nano-9b",
+            "nano-12b",
+            "lfm-2.5",
+            "gemma-4-31b",
+            "gemma-4-26b",
+        ),
+    ),
+)
+
+
+def detect_tier(model_id: str) -> ModelTier:
+    """Return the size tier for a non-frontier model id.
+
+    Frontier classification (claude-, gpt-5, gemini, grok) is handled by
+    GovernorConfig.is_strong_model and bypasses this function. If you call
+    it on a frontier id you'll get whatever size pattern matches first
+    (usually MEDIUM via "100b"-ish substrings) — caller is responsible.
+    """
+    lowered = model_id.lower()
+    for tier, patterns in TIER_PATTERNS:
+        for pattern in patterns:
+            if pattern in lowered:
+                return tier
+    return ModelTier.UNKNOWN
+
+
+def caps_for_tier(tier: ModelTier) -> TierCaps:
+    """Return the cap defaults for a given tier."""
+    return TIER_DEFAULTS.get(tier, TIER_DEFAULTS[ModelTier.UNKNOWN])

--- a/api/agent_governor/tiers.py
+++ b/api/agent_governor/tiers.py
@@ -76,15 +76,15 @@ TIER_DEFAULTS: dict[ModelTier, TierCaps] = {
         termination_hint=True,
     ),
     ModelTier.XL: TierCaps(
-        max_consecutive_tool_calls=40,
-        max_total_tool_calls=250,
+        max_consecutive_tool_calls=80,
+        max_total_tool_calls=400,
         tool_cull_max=80,
         plan_mode=False,
         termination_hint=True,
     ),
     ModelTier.XXL: TierCaps(
-        max_consecutive_tool_calls=60,
-        max_total_tool_calls=400,
+        max_consecutive_tool_calls=120,
+        max_total_tool_calls=600,
         tool_cull_max=100,
         plan_mode=False,
         termination_hint=False,  # 675B+ generally terminate themselves

--- a/api/agent_governor/tiers.py
+++ b/api/agent_governor/tiers.py
@@ -78,14 +78,14 @@ TIER_DEFAULTS: dict[ModelTier, TierCaps] = {
     ModelTier.XL: TierCaps(
         max_consecutive_tool_calls=40,
         max_total_tool_calls=250,
-        tool_cull_max=60,
+        tool_cull_max=80,
         plan_mode=False,
         termination_hint=True,
     ),
     ModelTier.XXL: TierCaps(
         max_consecutive_tool_calls=60,
         max_total_tool_calls=400,
-        tool_cull_max=80,
+        tool_cull_max=100,
         plan_mode=False,
         termination_hint=False,  # 675B+ generally terminate themselves
     ),

--- a/api/agent_governor/tool_cull.py
+++ b/api/agent_governor/tool_cull.py
@@ -1,0 +1,155 @@
+"""Keyword-relevance tool culling.
+
+Free models drown in 91-tool inventories. opencode loads ~41 and works fine.
+This module slims a request's tool list down to the ones most relevant to the
+user's latest question, by scoring each tool's name+description against tokens
+extracted from recent messages.
+
+Strategy: simple TF-style overlap. No embedding model, no extra calls. Tools
+that are universally useful (Read, Write, Edit, Bash, etc.) are pinned via
+``ALWAYS_KEEP`` regardless of score so the agent never loses fundamentals.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+# Names of tools the agent always needs, regardless of relevance score.
+# Matched case-insensitively, prefix match.
+ALWAYS_KEEP = (
+    "read",
+    "write",
+    "edit",
+    "bash",
+    "grep",
+    "glob",
+    "ls",
+    "todowrite",
+    "taskcreate",
+    "exitplanmode",
+    "askuserquestion",
+    "webfetch",
+    "websearch",
+)
+
+
+_TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9_\-]{2,}")
+_STOPWORDS = frozenset(
+    {
+        "the", "and", "for", "with", "this", "that", "you", "your", "from",
+        "have", "has", "are", "was", "will", "just", "can", "would", "could",
+        "should", "what", "how", "why", "when", "where", "which", "into",
+        "out", "use", "using", "used", "make", "made", "get", "got", "set",
+        "let", "see", "look", "show", "tell", "say", "does", "did", "doing",
+        "but", "not", "all", "any", "some", "more", "most", "less", "now",
+        "also", "very", "really", "still", "yet", "only", "even", "than",
+    }
+)
+
+
+@dataclass(slots=True)
+class CullResult:
+    """Outcome of a culling pass."""
+
+    kept_indices: tuple[int, ...]
+    dropped_count: int
+
+
+def _tokenize(text: str) -> set[str]:
+    return {
+        match.group(0).lower()
+        for match in _TOKEN_RE.finditer(text)
+        if match.group(0).lower() not in _STOPWORDS
+    }
+
+
+def _tool_text(tool: Any) -> str:
+    name = getattr(tool, "name", "") or ""
+    description = getattr(tool, "description", "") or ""
+    return f"{name} {description}"
+
+
+def _is_always_keep(tool: Any) -> bool:
+    name = (getattr(tool, "name", "") or "").lower()
+    return any(name == keep or name.startswith(keep + "_") for keep in ALWAYS_KEEP)
+
+
+def _extract_intent_text(messages: list[Any], system: Any) -> str:
+    """Combine the last user-text + system prompt into one intent string."""
+    chunks: list[str] = []
+    if isinstance(system, str):
+        chunks.append(system)
+    elif isinstance(system, list):
+        for item in system:
+            text = getattr(item, "text", None)
+            if isinstance(text, str):
+                chunks.append(text)
+            elif isinstance(item, dict):
+                t = item.get("text")
+                if isinstance(t, str):
+                    chunks.append(t)
+    # Last few user messages, prefer text blocks over tool_results.
+    user_texts: list[str] = []
+    for message in reversed(messages):
+        if getattr(message, "role", None) != "user":
+            continue
+        content = getattr(message, "content", None)
+        if isinstance(content, str):
+            user_texts.append(content)
+        elif isinstance(content, list):
+            for block in content:
+                if getattr(block, "type", None) == "text":
+                    text = getattr(block, "text", "")
+                    if text:
+                        user_texts.append(text)
+        if len(user_texts) >= 3:
+            break
+    chunks.extend(reversed(user_texts))
+    return " ".join(chunks)
+
+
+def cull_tools(
+    tools: list[Any],
+    messages: list[Any],
+    system: Any,
+    *,
+    max_keep: int,
+) -> CullResult:
+    """Return indices into ``tools`` to keep; drop the rest.
+
+    Indices are sorted ascending so the caller can rebuild a stable tools list.
+    If ``len(tools) <= max_keep``, returns all indices unchanged.
+    """
+    if len(tools) <= max_keep:
+        return CullResult(
+            kept_indices=tuple(range(len(tools))), dropped_count=0
+        )
+
+    intent_tokens = _tokenize(_extract_intent_text(messages, system))
+    pinned: list[int] = []
+    scored: list[tuple[int, int]] = []
+    for idx, tool in enumerate(tools):
+        if _is_always_keep(tool):
+            pinned.append(idx)
+            continue
+        tool_tokens = _tokenize(_tool_text(tool))
+        score = len(intent_tokens & tool_tokens) if intent_tokens else 0
+        scored.append((idx, score))
+
+    # Sort scored by score desc, original index asc as tiebreaker for stability.
+    scored.sort(key=lambda pair: (-pair[1], pair[0]))
+    remaining_slots = max(0, max_keep - len(pinned))
+    chosen = sorted(pinned + [idx for idx, _ in scored[:remaining_slots]])
+    return CullResult(
+        kept_indices=tuple(chosen), dropped_count=len(tools) - len(chosen)
+    )
+
+
+def apply_cull(tools: list[Any], result: CullResult) -> list[Any]:
+    """Rebuild the tools list using only kept indices."""
+    if result.dropped_count == 0:
+        return tools
+    return [tools[i] for i in result.kept_indices]

--- a/api/services.py
+++ b/api/services.py
@@ -17,6 +17,8 @@ from core.anthropic.sse import ANTHROPIC_SSE_RESPONSE_HEADERS
 from providers.base import BaseProvider
 from providers.exceptions import InvalidRequestError, ProviderError
 
+from api.agent_governor import AgentGovernor, GovernorAction
+
 from .model_router import ModelRouter
 from .models.anthropic import MessagesRequest, TokenCountRequest
 from .models.responses import TokenCountResponse
@@ -92,11 +94,13 @@ class ClaudeProxyService:
         provider_getter: ProviderGetter,
         model_router: ModelRouter | None = None,
         token_counter: TokenCounter = get_token_count,
+        agent_governor: AgentGovernor | None = None,
     ):
         self._settings = settings
         self._provider_getter = provider_getter
         self._model_router = model_router or ModelRouter(settings)
         self._token_counter = token_counter
+        self._agent_governor = agent_governor or AgentGovernor()
 
     def create_message(self, request_data: MessagesRequest) -> object:
         """Create a message response or streaming response."""
@@ -111,6 +115,27 @@ class ClaudeProxyService:
                 )
                 if tool_err is not None:
                     raise InvalidRequestError(tool_err)
+
+            # Agent governor: weak-model loop prevention + tool culling.
+            governor_request_id = f"req_{uuid.uuid4().hex[:12]}"
+            verdict = self._agent_governor.review(
+                routed.request,
+                request_id=governor_request_id,
+                provider_id=routed.resolved.provider_id,
+            )
+            if verdict.action == GovernorAction.ABORT:
+                if verdict.short_circuit_response is None:
+                    raise RuntimeError(
+                        "Governor returned ABORT without a short-circuit response"
+                    )
+                return verdict.short_circuit_response
+            if verdict.action == GovernorAction.AUGMENT and verdict.augmented_request is not None:
+                from api.model_router import RoutedMessagesRequest
+
+                routed = RoutedMessagesRequest(
+                    request=verdict.augmented_request,
+                    resolved=routed.resolved,
+                )
 
             if self._settings.enable_web_server_tools and is_web_server_tool_request(
                 routed.request

--- a/tests/api/agent_governor/test_conversation_stats.py
+++ b/tests/api/agent_governor/test_conversation_stats.py
@@ -1,0 +1,109 @@
+"""Tests for ConversationStats — tool-call counters and recent signatures."""
+
+from __future__ import annotations
+
+from api.models.anthropic import (
+    ContentBlockText,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    Message,
+)
+from api.agent_governor.conversation_stats import compute_stats
+
+
+def _user_text(text: str) -> Message:
+    return Message(role="user", content=[ContentBlockText(type="text", text=text)])
+
+
+def _assistant_text(text: str) -> Message:
+    return Message(
+        role="assistant", content=[ContentBlockText(type="text", text=text)]
+    )
+
+
+def _assistant_tool_use(name: str, args: dict, tool_id: str = "t") -> Message:
+    return Message(
+        role="assistant",
+        content=[
+            ContentBlockToolUse(
+                type="tool_use", id=tool_id, name=name, input=args
+            )
+        ],
+    )
+
+
+def _user_tool_result(tool_use_id: str, content: str) -> Message:
+    return Message(
+        role="user",
+        content=[
+            ContentBlockToolResult(
+                type="tool_result", tool_use_id=tool_use_id, content=content
+            )
+        ],
+    )
+
+
+def test_empty_history():
+    stats = compute_stats([])
+    assert stats.total_messages == 0
+    assert stats.total_tool_calls == 0
+    assert stats.consecutive_tool_calls == 0
+    assert stats.recent_tool_calls == []
+
+
+def test_single_user_message_no_tools():
+    stats = compute_stats([_user_text("hi")])
+    assert stats.total_tool_calls == 0
+    assert stats.consecutive_tool_calls == 0
+
+
+def test_text_assistant_resets_streak():
+    msgs = [
+        _user_text("do thing"),
+        _assistant_tool_use("read", {"path": "a"}, "t1"),
+        _user_tool_result("t1", "ok"),
+        _assistant_text("done"),
+    ]
+    stats = compute_stats(msgs)
+    assert stats.total_tool_calls == 1
+    assert stats.consecutive_tool_calls == 0
+    assert stats.last_assistant_text_len == 4
+
+
+def test_consecutive_tool_calls_with_tool_results():
+    msgs = [
+        _user_text("do thing"),
+        _assistant_tool_use("read", {"path": "a"}, "t1"),
+        _user_tool_result("t1", "ok"),
+        _assistant_tool_use("read", {"path": "b"}, "t2"),
+        _user_tool_result("t2", "ok"),
+        _assistant_tool_use("read", {"path": "c"}, "t3"),
+        _user_tool_result("t3", "ok"),
+    ]
+    stats = compute_stats(msgs)
+    assert stats.total_tool_calls == 3
+    assert stats.consecutive_tool_calls == 3
+
+
+def test_user_text_resets_streak():
+    msgs = [
+        _assistant_tool_use("read", {"path": "a"}, "t1"),
+        _user_tool_result("t1", "ok"),
+        _user_text("new question"),
+        _assistant_tool_use("read", {"path": "b"}, "t2"),
+    ]
+    stats = compute_stats(msgs)
+    assert stats.total_tool_calls == 2
+    assert stats.consecutive_tool_calls == 1
+
+
+def test_recent_tool_calls_window():
+    msgs = []
+    for i in range(12):
+        msgs.append(_assistant_tool_use("read", {"path": f"f{i}"}, f"t{i}"))
+        msgs.append(_user_tool_result(f"t{i}", "ok"))
+    stats = compute_stats(msgs, recent_window=5)
+    assert len(stats.recent_tool_calls) == 5
+    # The window should contain the LAST 5 calls (f7..f11).
+    names = [ref.name for ref in stats.recent_tool_calls]
+    assert names == ["read", "read", "read", "read", "read"]

--- a/tests/api/agent_governor/test_governor.py
+++ b/tests/api/agent_governor/test_governor.py
@@ -1,0 +1,193 @@
+"""End-to-end behaviour tests for the AgentGovernor verdict pipeline."""
+
+from __future__ import annotations
+
+from api.models.anthropic import (
+    ContentBlockText,
+    ContentBlockToolResult,
+    ContentBlockToolUse,
+    Message,
+    MessagesRequest,
+    Tool,
+)
+from api.agent_governor import AgentGovernor, GovernorAction
+from api.agent_governor.config import GovernorConfig
+
+
+def _request(
+    *,
+    model: str = "qwen/qwen3-next-80b-a3b-instruct",
+    messages: list[Message] | None = None,
+    tools: list[Tool] | None = None,
+    system: str | None = None,
+) -> MessagesRequest:
+    return MessagesRequest(
+        model=model,
+        max_tokens=4096,
+        messages=messages
+        or [Message(role="user", content=[ContentBlockText(type="text", text="hi")])],
+        tools=tools,
+        system=system,
+    )
+
+
+def _tool_use_message(name: str, args: dict, tool_id: str) -> Message:
+    return Message(
+        role="assistant",
+        content=[ContentBlockToolUse(type="tool_use", id=tool_id, name=name, input=args)],
+    )
+
+
+def _tool_result_message(tool_id: str) -> Message:
+    return Message(
+        role="user",
+        content=[
+            ContentBlockToolResult(
+                type="tool_result", tool_use_id=tool_id, content="ok"
+            )
+        ],
+    )
+
+
+def _disabled_governor() -> AgentGovernor:
+    return AgentGovernor(GovernorConfig(enabled=False))
+
+
+def _default_weak_governor() -> AgentGovernor:
+    return AgentGovernor(GovernorConfig())
+
+
+def test_disabled_governor_passes_through():
+    gov = _disabled_governor()
+    verdict = gov.review(_request(), request_id="req_x", provider_id="nvidia_nim")
+    assert verdict.action == GovernorAction.PASS
+    assert verdict.augmented_request is None
+
+
+def test_strong_model_bypasses_governor():
+    gov = AgentGovernor(GovernorConfig())
+    verdict = gov.review(
+        _request(model="claude-sonnet-4-6"),
+        request_id="req_x",
+        provider_id="anthropic",
+    )
+    assert verdict.action == GovernorAction.PASS
+
+
+def test_total_budget_aborts():
+    cfg = GovernorConfig(max_total_tool_calls=3)
+    gov = AgentGovernor(cfg)
+    msgs = []
+    for i in range(3):
+        msgs.append(_tool_use_message("read", {"path": f"f{i}"}, f"t{i}"))
+        msgs.append(_tool_result_message(f"t{i}"))
+    verdict = gov.review(
+        _request(messages=msgs), request_id="req_x", provider_id="nvidia_nim"
+    )
+    assert verdict.action == GovernorAction.ABORT
+    assert verdict.short_circuit_response is not None
+    assert verdict.short_circuit_response.stop_reason == "end_turn"
+    assert "total_tool_budget_exceeded" in verdict.short_circuit_response.content[0].text
+
+
+def test_loop_signature_aborts_before_budget():
+    cfg = GovernorConfig(max_total_tool_calls=1000, loop_repeat_threshold=3)
+    gov = AgentGovernor(cfg)
+    msgs = []
+    for i in range(3):
+        msgs.append(_tool_use_message("read", {"path": "/etc/hosts"}, f"t{i}"))
+        msgs.append(_tool_result_message(f"t{i}"))
+    verdict = gov.review(
+        _request(messages=msgs), request_id="req_x", provider_id="nvidia_nim"
+    )
+    assert verdict.action == GovernorAction.ABORT
+    assert "loop_signature_detected" in verdict.short_circuit_response.content[0].text
+
+
+def test_consecutive_cap_aborts():
+    cfg = GovernorConfig(
+        max_total_tool_calls=1000,
+        max_consecutive_tool_calls=2,
+        loop_repeat_threshold=99,
+    )
+    gov = AgentGovernor(cfg)
+    msgs = []
+    for i in range(2):
+        msgs.append(_tool_use_message("read", {"path": f"f{i}"}, f"t{i}"))
+        msgs.append(_tool_result_message(f"t{i}"))
+    verdict = gov.review(
+        _request(messages=msgs), request_id="req_x", provider_id="nvidia_nim"
+    )
+    assert verdict.action == GovernorAction.ABORT
+    assert "consecutive_tool_calls_exceeded" in verdict.short_circuit_response.content[0].text
+
+
+def test_augment_culls_tools_when_over_threshold():
+    cfg = GovernorConfig(
+        tool_cull_max=5,
+        plan_mode_for_weak=False,
+        termination_hint_for_weak=False,
+    )
+    gov = AgentGovernor(cfg)
+    tools = [Tool(name=f"tool_{i}", description=f"thing {i}") for i in range(20)]
+    verdict = gov.review(
+        _request(tools=tools), request_id="req_x", provider_id="nvidia_nim"
+    )
+    assert verdict.action == GovernorAction.AUGMENT
+    assert verdict.augmented_request is not None
+    assert len(verdict.augmented_request.tools) <= 5
+
+
+def test_augment_appends_plan_mode_for_weak_models():
+    cfg = GovernorConfig(
+        tool_cull_enabled=False,
+        plan_mode_for_weak=True,
+        termination_hint_for_weak=False,
+    )
+    gov = AgentGovernor(cfg)
+    verdict = gov.review(
+        _request(system="You are helpful."),
+        request_id="req_x",
+        provider_id="nvidia_nim",
+    )
+    assert verdict.action == GovernorAction.AUGMENT
+    assert "[Operating mode: plan-then-execute]" in verdict.augmented_request.system
+
+
+def test_augment_appends_termination_hint_for_weak_models():
+    cfg = GovernorConfig(
+        tool_cull_enabled=False,
+        plan_mode_for_weak=False,
+        termination_hint_for_weak=True,
+    )
+    gov = AgentGovernor(cfg)
+    verdict = gov.review(
+        _request(system="You are helpful."),
+        request_id="req_x",
+        provider_id="nvidia_nim",
+    )
+    assert verdict.action == GovernorAction.AUGMENT
+    assert "[Termination policy]" in verdict.augmented_request.system
+
+
+def test_strong_model_keeps_all_tools_and_no_preamble():
+    cfg = GovernorConfig(tool_cull_max=5)
+    gov = AgentGovernor(cfg)
+    tools = [Tool(name=f"tool_{i}", description=f"thing {i}") for i in range(20)]
+    verdict = gov.review(
+        _request(model="claude-sonnet-4-6", tools=tools, system="You are helpful."),
+        request_id="req_x",
+        provider_id="anthropic",
+    )
+    assert verdict.action == GovernorAction.PASS
+
+
+def test_clean_simple_request_passes():
+    gov = _default_weak_governor()
+    verdict = gov.review(_request(), request_id="req_x", provider_id="nvidia_nim")
+    # No tools, no history → only the weak-model preambles get added.
+    # plan_mode_for_weak + termination_hint_for_weak both default to True,
+    # so we expect AUGMENT here, not PASS.
+    assert verdict.action == GovernorAction.AUGMENT
+    assert "[Operating mode: plan-then-execute]" in verdict.augmented_request.system
+    assert "[Termination policy]" in verdict.augmented_request.system

--- a/tests/api/agent_governor/test_loop_detect.py
+++ b/tests/api/agent_governor/test_loop_detect.py
@@ -1,0 +1,48 @@
+"""Tests for the same-tool same-args loop detector."""
+
+from __future__ import annotations
+
+from api.agent_governor.conversation_stats import ConversationStats, ToolCallRef
+from api.agent_governor.loop_detect import detect_repeated_signature
+
+
+def _stats(*refs: ToolCallRef) -> ConversationStats:
+    return ConversationStats(
+        total_messages=len(refs),
+        total_tool_calls=len(refs),
+        consecutive_tool_calls=len(refs),
+        recent_tool_calls=list(refs),
+    )
+
+
+def test_no_repeats():
+    s = _stats(
+        ToolCallRef("read", "a1"),
+        ToolCallRef("write", "b2"),
+        ToolCallRef("bash", "c3"),
+    )
+    assert detect_repeated_signature(s, threshold=3) is None
+
+
+def test_three_repeats_of_same_tool_same_args():
+    ref = ToolCallRef("read", "abc")
+    s = _stats(ref, ref, ref)
+    out = detect_repeated_signature(s, threshold=3)
+    assert out is not None
+    assert out.name == "read"
+
+
+def test_same_tool_different_args_does_not_trigger():
+    s = _stats(
+        ToolCallRef("read", "x1"),
+        ToolCallRef("read", "x2"),
+        ToolCallRef("read", "x3"),
+    )
+    assert detect_repeated_signature(s, threshold=3) is None
+
+
+def test_threshold_below_two_disables():
+    ref = ToolCallRef("read", "abc")
+    s = _stats(ref, ref, ref)
+    assert detect_repeated_signature(s, threshold=1) is None
+    assert detect_repeated_signature(s, threshold=0) is None

--- a/tests/api/agent_governor/test_tiers.py
+++ b/tests/api/agent_governor/test_tiers.py
@@ -49,7 +49,7 @@ def test_detect_tier_unknown_returns_unknown():
 def test_caps_for_tier_returns_defaults():
     caps = caps_for_tier(ModelTier.XL)
     assert caps == TIER_DEFAULTS[ModelTier.XL]
-    assert caps.max_consecutive_tool_calls == 40
+    assert caps.max_consecutive_tool_calls == 80
 
 
 def test_tier_caps_strictly_increase_with_size():

--- a/tests/api/agent_governor/test_tiers.py
+++ b/tests/api/agent_governor/test_tiers.py
@@ -1,0 +1,167 @@
+"""Tests for size-tier classification + per-tier cap defaults."""
+
+from __future__ import annotations
+
+import pytest
+
+from api.agent_governor.config import (
+    GovernorConfig,
+    ModelOverride,
+    load_governor_config,
+)
+from api.agent_governor.tiers import (
+    TIER_DEFAULTS,
+    ModelTier,
+    caps_for_tier,
+    detect_tier,
+)
+
+
+@pytest.mark.parametrize(
+    "model_id, expected",
+    [
+        # Frontier → not handled by detect_tier; covered separately below.
+        ("nvidia/llama-3.3-nemotron-super-49b-v1.5", ModelTier.SMALL),
+        ("qwen/qwen3-next-80b-a3b-instruct", ModelTier.SMALL),
+        ("meta-llama/llama-3.3-70b-instruct", ModelTier.SMALL),
+        ("openai/gpt-oss-20b", ModelTier.TINY),
+        ("nvidia/nemotron-3-nano-30b-a3b", ModelTier.TINY),
+        ("nvidia/nemotron-3-super-120b-a12b", ModelTier.MEDIUM),
+        ("openai/gpt-oss-120b", ModelTier.MEDIUM),
+        ("z-ai/glm-4.5-air", ModelTier.MEDIUM),
+        ("z-ai/glm-4.6", ModelTier.MEDIUM),
+        ("nvidia/llama-3.1-nemotron-ultra-253b-v1", ModelTier.LARGE),
+        ("deepseek-ai/deepseek-v4-pro", ModelTier.LARGE),
+        ("qwen/qwen3-coder-480b-a35b-instruct", ModelTier.XL),
+        ("nousresearch/hermes-3-llama-3.1-405b", ModelTier.XL),
+        ("inclusionai/ring-2.6-1t", ModelTier.XL),
+        ("mistralai/mistral-large-3-675b-instruct-2512", ModelTier.XXL),
+    ],
+)
+def test_detect_tier_known_models(model_id: str, expected: ModelTier):
+    assert detect_tier(model_id) == expected
+
+
+def test_detect_tier_unknown_returns_unknown():
+    assert detect_tier("totally/made-up-model") == ModelTier.UNKNOWN
+
+
+def test_caps_for_tier_returns_defaults():
+    caps = caps_for_tier(ModelTier.XL)
+    assert caps == TIER_DEFAULTS[ModelTier.XL]
+    assert caps.max_consecutive_tool_calls == 40
+
+
+def test_tier_caps_strictly_increase_with_size():
+    """Bigger tier → wider headroom across all numeric caps."""
+    ordered = (
+        ModelTier.TINY,
+        ModelTier.SMALL,
+        ModelTier.MEDIUM,
+        ModelTier.LARGE,
+        ModelTier.XL,
+        ModelTier.XXL,
+    )
+    for left, right in zip(ordered[:-1], ordered[1:], strict=True):
+        l_caps, r_caps = TIER_DEFAULTS[left], TIER_DEFAULTS[right]
+        assert l_caps.max_consecutive_tool_calls < r_caps.max_consecutive_tool_calls
+        assert l_caps.max_total_tool_calls < r_caps.max_total_tool_calls
+        assert l_caps.tool_cull_max < r_caps.tool_cull_max
+
+
+def test_governor_config_tier_for_strong_returns_frontier():
+    cfg = GovernorConfig()
+    assert cfg.tier_for("claude-sonnet-4-6") == ModelTier.FRONTIER
+    assert cfg.tier_for("gpt-5") == ModelTier.FRONTIER
+
+
+def test_governor_config_for_model_uses_tier_defaults():
+    """A vanilla config falls back to tier defaults when env caps are unset."""
+    cfg = GovernorConfig()  # all caps None → should resolve from tier
+    resolved_xl = cfg.for_model("qwen/qwen3-coder-480b-a35b-instruct")
+    assert resolved_xl.max_consecutive_tool_calls == TIER_DEFAULTS[
+        ModelTier.XL
+    ].max_consecutive_tool_calls
+    assert resolved_xl.tool_cull_max == TIER_DEFAULTS[ModelTier.XL].tool_cull_max
+
+    resolved_tiny = cfg.for_model("nvidia/nemotron-3-nano-30b-a3b")
+    assert resolved_tiny.max_consecutive_tool_calls == TIER_DEFAULTS[
+        ModelTier.TINY
+    ].max_consecutive_tool_calls
+    # XL must get a wider cap than TINY.
+    assert (
+        resolved_xl.max_consecutive_tool_calls
+        > resolved_tiny.max_consecutive_tool_calls
+    )
+
+
+def test_governor_config_global_env_overrides_tier_defaults():
+    """If an env-level value is set, every model uses it regardless of tier."""
+    cfg = GovernorConfig(max_consecutive_tool_calls=12)  # global override
+    resolved_tiny = cfg.for_model("nvidia/nemotron-3-nano-30b-a3b")
+    resolved_xl = cfg.for_model("qwen/qwen3-coder-480b-a35b-instruct")
+    assert resolved_tiny.max_consecutive_tool_calls == 12
+    assert resolved_xl.max_consecutive_tool_calls == 12
+
+
+def test_governor_config_per_model_override_beats_tier_and_env():
+    cfg = GovernorConfig(
+        max_consecutive_tool_calls=12,  # global env-level override
+        overrides={
+            "qwen3-coder-480b": ModelOverride(max_consecutive_tool_calls=99)
+        },
+    )
+    resolved_xl = cfg.for_model("qwen/qwen3-coder-480b-a35b-instruct")
+    resolved_other = cfg.for_model("qwen/qwen3-next-80b-a3b-instruct")
+    assert resolved_xl.max_consecutive_tool_calls == 99
+    assert resolved_other.max_consecutive_tool_calls == 12  # env wins
+
+
+def test_governor_config_per_model_can_force_a_tier():
+    """An override can pin the tier explicitly (e.g. force a tiny model into 'medium')."""
+    cfg = GovernorConfig(
+        overrides={
+            "weird-model": ModelOverride(tier=ModelTier.LARGE),
+        }
+    )
+    assert cfg.tier_for("weird-model") == ModelTier.LARGE
+    resolved = cfg.for_model("weird-model")
+    assert resolved.max_consecutive_tool_calls == TIER_DEFAULTS[
+        ModelTier.LARGE
+    ].max_consecutive_tool_calls
+
+
+def test_load_governor_config_env_tier_caps_json(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv(
+        "GOVERNOR_TIER_CAPS_JSON",
+        '{"xl": {"max_consecutive_tool_calls": 99, "tool_cull_max": 70}}',
+    )
+    cfg = load_governor_config()
+    xl_caps = cfg.tier_caps[ModelTier.XL]
+    assert xl_caps.max_consecutive_tool_calls == 99
+    assert xl_caps.tool_cull_max == 70
+    # Other tiers untouched.
+    assert (
+        cfg.tier_caps[ModelTier.SMALL].max_consecutive_tool_calls
+        == TIER_DEFAULTS[ModelTier.SMALL].max_consecutive_tool_calls
+    )
+
+
+def test_load_governor_config_unset_env_returns_none_caps(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Unset env caps remain None at process level so tier defaults can fill in."""
+    for var in (
+        "GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS",
+        "GOVERNOR_MAX_TOTAL_TOOL_CALLS",
+        "GOVERNOR_TOOL_CULL_MAX",
+        "GOVERNOR_PLAN_MODE_FOR_WEAK",
+        "GOVERNOR_TERMINATION_HINT_FOR_WEAK",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    cfg = load_governor_config()
+    assert cfg.max_consecutive_tool_calls is None
+    assert cfg.max_total_tool_calls is None
+    assert cfg.tool_cull_max is None
+    assert cfg.plan_mode_for_weak is None
+    assert cfg.termination_hint_for_weak is None

--- a/tests/api/agent_governor/test_tool_cull.py
+++ b/tests/api/agent_governor/test_tool_cull.py
@@ -1,0 +1,70 @@
+"""Tests for keyword-relevance tool culling."""
+
+from __future__ import annotations
+
+from api.models.anthropic import (
+    ContentBlockText,
+    Message,
+    Tool,
+)
+from api.agent_governor.tool_cull import apply_cull, cull_tools
+
+
+def _tool(name: str, description: str = "") -> Tool:
+    return Tool(name=name, description=description)
+
+
+def _user(text: str) -> Message:
+    return Message(role="user", content=[ContentBlockText(type="text", text=text)])
+
+
+def test_culling_a_short_list_returns_unchanged():
+    tools = [_tool("read"), _tool("write")]
+    msgs = [_user("hello")]
+    result = cull_tools(tools, msgs, system="", max_keep=10)
+    assert result.dropped_count == 0
+    assert apply_cull(tools, result) == tools
+
+
+def test_always_keep_pinned_even_when_irrelevant():
+    tools = [
+        _tool("read", "read a file"),
+        _tool("write", "write a file"),
+        _tool("bash", "run a shell command"),
+        _tool("grep", "search files"),
+        _tool("glob", "list files matching a pattern"),
+        _tool("fancy_postgres_explainer", "analyse pg query plans"),
+        _tool("kubernetes_audit", "audit a kubernetes cluster"),
+        _tool("slack_post", "send a message to slack"),
+        _tool("jira_create", "open a jira ticket"),
+        _tool("salesforce_query", "query SFDC"),
+        _tool("ad_creative_generator", "generate ads"),
+        _tool("airtable_read", "read airtable"),
+        _tool("notion_write", "write to notion"),
+    ]
+    msgs = [_user("can you tell me a joke")]
+    result = cull_tools(tools, msgs, system="", max_keep=5)
+    kept_names = [tools[i].name for i in result.kept_indices]
+    # All ALWAYS_KEEP tools survive.
+    for must_keep in ("read", "write", "bash", "grep", "glob"):
+        assert must_keep in kept_names, f"{must_keep} should be pinned"
+
+
+def test_culling_keeps_relevant_tools_first():
+    tools = [
+        _tool("read"),
+        _tool("write"),
+        _tool("bash"),
+        _tool("grep"),
+        _tool("glob"),
+        _tool("postgres_query", "execute postgres SQL queries"),
+        _tool("kubernetes_audit", "audit kubernetes cluster"),
+        _tool("slack_post", "send slack messages"),
+    ]
+    msgs = [_user("can you check the postgres database tables for me")]
+    result = cull_tools(tools, msgs, system="", max_keep=6)
+    kept_names = [tools[i].name for i in result.kept_indices]
+    # postgres_query scored highest non-pinned, must survive.
+    assert "postgres_query" in kept_names
+    # 5 always-keep + postgres_query = 6 kept; nothing else.
+    assert len(kept_names) == 6


### PR DESCRIPTION
## Summary

Adds a stateless **agent governor** that prevents the most common failure mode for open-weight models in agentic Claude Code sessions: **infinite tool-call loops with no termination signal**.

Real-world incident on `qwen/qwen3-next-80b-a3b-instruct` via NIM:
- 461 → 485 messages accumulated overnight
- Upstream HTTP stream stayed open for **8.5 hours** before NIM finally timed it out as a `ReadTimeout`
- Cause: model never emitted `stop_reason=end_turn` because RLHF didn't teach termination strongly enough

opencode running the same NIM models doesn't hit this — its log shows it only loads ~41 tools (vs. Claude Code's typical 91). Fewer tools = better tool selection = the loop terminates naturally. The governor brings the same hygiene to fcc.

## What it does

Six configurable interventions, invoked once per `/v1/messages` request, **after** model routing, **before** provider streaming. Strong models (Claude, GPT-5, GPT-4, o1/o3/o4, Grok, Gemini) bypass the governor entirely.

### Hard aborts (terminate the loop)
1. **Total tool-call budget** per conversation — `GOVERNOR_MAX_TOTAL_TOOL_CALLS` (default 40)
2. **Loop signature detector** — same tool + same args repeated 3+ times → `GOVERNOR_LOOP_REPEAT_THRESHOLD`
3. **Consecutive tool-call cap** — N tool_use turns in a row without an assistant text → `GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS` (default 8)

### Augmentations (modify the request, continue)
4. **Tool culling** — keyword-relevance scoring keeps the top N tools + a pinned core (`read`, `write`, `edit`, `bash`, `grep`, `glob`, `ls`, `todowrite`, …). `GOVERNOR_TOOL_CULL_MAX` (default 25).
5. **Plan-mode preamble** for weak models — appends an instruction to write a 5-step plan before tool-calling. Plan completion acts as a soft stop signal.
6. **Termination hint** for weak models — appends an instruction telling the model that text-only output is a valid answer.

### Telemetry

Each request emits one structured log line:

```
GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=augment consecutive_tools=3 total_tools=14 tools_in=91 tools_after_cull=25 intervention=tool_cull(-66),plan_mode,termination_hint
GOVERNOR: request_id=req_abc model=qwen/qwen3-next-80b action=abort   consecutive_tools=8 total_tools=27 tools_in=25 intervention=consecutive_tools reason=cap_reached
```

## Configuration

All env vars; aggressive-but-safe defaults. Master toggle: `GOVERNOR_ENABLED=true|false`. See [`api/agent_governor/README.md`](api/agent_governor/README.md) for the full table including per-model JSON overrides.

## Architecture

The governor is **stateless** — every decision is derived from the request's own `messages` array. Claude Code re-sends the full conversation each turn, so no per-session storage is needed. Single insertion point in `api/services.py:create_message`.

Module sits under `api/` (not `core/`) because it operates on `MessagesRequest` / `MessagesResponse` Anthropic API types. Existing `tests/contracts/test_import_boundaries.py` is respected.

## Files

```
api/agent_governor/
├── __init__.py            # exports
├── config.py              # env loading + per-model overrides
├── conversation_stats.py  # pure history walker
├── loop_detect.py         # repeated-signature detector
├── tool_cull.py           # keyword culling + always-keep set
├── system_augmentation.py # preamble injection
├── governor.py            # orchestrator + Verdict
├── telemetry.py           # structured logging
└── README.md              # design notes
api/services.py            # single insertion point
tests/api/agent_governor/  # 23 unit tests (every intervention)
```

Net: **+1,594 lines / -1 line**. No existing code paths altered besides the single insertion point in `services.py`.

## Test plan

- [x] **23 new unit tests** for the governor itself, covering every intervention path including strong-model bypass.
- [x] **`tests/contracts/test_import_boundaries.py` passes** — governor lives under `api/` per the architectural rule that `core/` cannot import from `api/`.
- [x] **Full upstream test suite passes**: `pytest tests/` → **1227 passed, 0 failed**.
- [ ] Reviewer: verify behaviour against a real NIM agentic session — set `GOVERNOR_MAX_CONSECUTIVE_TOOL_CALLS=4` and trigger a loop; expect `action=abort`, `intervention=consecutive_tools` log line.
- [ ] Reviewer: verify strong-model bypass — set model to `claude-sonnet-4-6`, confirm zero governor intervention even with 100+ tools loaded.
- [ ] Reviewer: verify env-disabled — set `GOVERNOR_ENABLED=false`, confirm complete pass-through.

## What this does NOT solve

- **NIM upstream flakiness** (502, RemoteProtocolError, ReadTimeout). What it does fix: those failures now happen *fast* because the abort path returns immediately rather than re-streaming endlessly.
- **Tool description quality**: the keyword scorer is only as good as the descriptions tools provide. If MCP authors give better descriptions, culling improves automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)