### PR TITLE
feat: add Astraflow provider support (global + China endpoints)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ OPENCODE_API_KEY=""
 ZAI_API_KEY=""
 ZAI_BASE_URL="https://api.z.ai/api/coding/paas/v4"
 
+# Astraflow Config (OpenAI-compatible, 200+ models — https://astraflow.ucloud-global.com)
+# Global endpoint
+ASTRAFLOW_API_KEY=""
+# China endpoint
+ASTRAFLOW_CN_API_KEY=""
+
 
 # LM Studio Config (local provider, no API key required)
 LM_STUDIO_BASE_URL="http://localhost:1234/v1"
@@ -41,7 +47,7 @@ OLLAMA_BASE_URL="http://localhost:11434"
 
 # All Claude model requests are mapped to these models, plain model is fallback
 # Format: provider_type/model/name
-# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "ollama" | "kimi" | "wafer" | "opencode" | "zai"
+# Valid providers: "nvidia_nim" | "open_router" | "deepseek" | "lmstudio" | "llamacpp" | "ollama" | "kimi" | "wafer" | "opencode" | "zai" | "astraflow" | "astraflow_cn"
 MODEL_OPUS=
 MODEL_SONNET=
 MODEL_HAIKU=
@@ -60,6 +66,8 @@ FCC_SMOKE_MODEL_KIMI=
 FCC_SMOKE_MODEL_WAFER=
 FCC_SMOKE_MODEL_OPENCODE=
 FCC_SMOKE_MODEL_ZAI=
+FCC_SMOKE_MODEL_ASTRAFLOW=
+FCC_SMOKE_MODEL_ASTRAFLOW_CN=
 FCC_SMOKE_NIM_MODELS=
 FCC_SMOKE_NIM_EXTRA_MODELS=
 FCC_SMOKE_OPENROUTER_FREE_MODELS=
@@ -85,6 +93,8 @@ KIMI_PROXY=""
 WAFER_PROXY=""
 OPENCODE_PROXY=""
 ZAI_PROXY=""
+ASTRAFLOW_PROXY=""
+ASTRAFLOW_CN_PROXY=""
 
 PROVIDER_RATE_LIMIT=1
 PROVIDER_RATE_WINDOW=3

--- a/config/provider_catalog.py
+++ b/config/provider_catalog.py
@@ -25,6 +25,8 @@ LLAMACPP_DEFAULT_BASE = "http://localhost:8080/v1"
 OLLAMA_DEFAULT_BASE = "http://localhost:11434"
 OPENCODE_DEFAULT_BASE = "https://opencode.ai/zen/v1"
 ZAI_DEFAULT_BASE = "https://api.z.ai/api/coding/paas/v4"
+ASTRAFLOW_DEFAULT_BASE = "https://api-us-ca.umodelverse.ai/v1"
+ASTRAFLOW_CN_DEFAULT_BASE = "https://api.modelverse.cn/v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,6 +147,26 @@ PROVIDER_CATALOG: dict[str, ProviderDescriptor] = {
         base_url_attr="zai_base_url",
         proxy_attr="zai_proxy",
         capabilities=("chat", "streaming", "tools", "thinking", "rate_limit"),
+    ),
+    "astraflow": ProviderDescriptor(
+        provider_id="astraflow",
+        transport_type="openai_chat",
+        credential_env="ASTRAFLOW_API_KEY",
+        credential_url="https://astraflow.ucloud-global.com",
+        credential_attr="astraflow_api_key",
+        default_base_url=ASTRAFLOW_DEFAULT_BASE,
+        proxy_attr="astraflow_proxy",
+        capabilities=("chat", "streaming", "tools", "rate_limit"),
+    ),
+    "astraflow_cn": ProviderDescriptor(
+        provider_id="astraflow_cn",
+        transport_type="openai_chat",
+        credential_env="ASTRAFLOW_CN_API_KEY",
+        credential_url="https://astraflow.ucloud.cn",
+        credential_attr="astraflow_cn_api_key",
+        default_base_url=ASTRAFLOW_CN_DEFAULT_BASE,
+        proxy_attr="astraflow_cn_proxy",
+        capabilities=("chat", "streaming", "tools", "rate_limit"),
     ),
 }
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -128,6 +128,10 @@ class Settings(BaseSettings):
         validation_alias="ZAI_BASE_URL",
     )
 
+    # ==================== Astraflow Config ====================
+    astraflow_api_key: str = Field(default="", validation_alias="ASTRAFLOW_API_KEY")
+    astraflow_cn_api_key: str = Field(default="", validation_alias="ASTRAFLOW_CN_API_KEY")
+
     # ==================== Messaging Platform Selection ====================
     # Valid: "telegram" | "discord" | "none"
     messaging_platform: str = Field(
@@ -181,6 +185,8 @@ class Settings(BaseSettings):
     wafer_proxy: str = Field(default="", validation_alias="WAFER_PROXY")
     opencode_proxy: str = Field(default="", validation_alias="OPENCODE_PROXY")
     zai_proxy: str = Field(default="", validation_alias="ZAI_PROXY")
+    astraflow_proxy: str = Field(default="", validation_alias="ASTRAFLOW_PROXY")
+    astraflow_cn_proxy: str = Field(default="", validation_alias="ASTRAFLOW_CN_PROXY")
 
     # ==================== Provider Rate Limiting ====================
     provider_rate_limit: int = Field(default=40, validation_alias="PROVIDER_RATE_LIMIT")

--- a/providers/astraflow/__init__.py
+++ b/providers/astraflow/__init__.py
@@ -1,0 +1,12 @@
+"""Astraflow provider exports."""
+
+from providers.defaults import ASTRAFLOW_DEFAULT_BASE, ASTRAFLOW_CN_DEFAULT_BASE
+
+from .client import AstraflowProvider, AstraflowCNProvider
+
+__all__ = [
+    "ASTRAFLOW_DEFAULT_BASE",
+    "ASTRAFLOW_CN_DEFAULT_BASE",
+    "AstraflowProvider",
+    "AstraflowCNProvider",
+]

--- a/providers/astraflow/client.py
+++ b/providers/astraflow/client.py
@@ -1,0 +1,51 @@
+"""Astraflow provider implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from providers.base import ProviderConfig
+from providers.defaults import ASTRAFLOW_DEFAULT_BASE, ASTRAFLOW_CN_DEFAULT_BASE
+from providers.openai_compat import OpenAIChatTransport
+
+from .request import build_request_body
+
+
+class AstraflowProvider(OpenAIChatTransport):
+    """Astraflow global provider (OpenAI-compatible, endpoint: api-us-ca.umodelverse.ai)."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="ASTRAFLOW",
+            base_url=config.base_url or ASTRAFLOW_DEFAULT_BASE,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+        )
+
+
+class AstraflowCNProvider(OpenAIChatTransport):
+    """Astraflow China provider (OpenAI-compatible, endpoint: api.modelverse.cn)."""
+
+    def __init__(self, config: ProviderConfig):
+        super().__init__(
+            config,
+            provider_name="ASTRAFLOW_CN",
+            base_url=config.base_url or ASTRAFLOW_CN_DEFAULT_BASE,
+            api_key=config.api_key,
+        )
+
+    def _build_request_body(
+        self, request: Any, thinking_enabled: bool | None = None
+    ) -> dict:
+        return build_request_body(
+            request,
+            thinking_enabled=self._is_thinking_enabled(request, thinking_enabled),
+        )

--- a/providers/astraflow/request.py
+++ b/providers/astraflow/request.py
@@ -1,0 +1,33 @@
+"""Request builder for Astraflow provider."""
+
+from typing import Any
+
+from loguru import logger
+
+from core.anthropic import ReasoningReplayMode, build_base_request_body
+from core.anthropic.conversion import OpenAIConversionError
+from providers.exceptions import InvalidRequestError
+
+
+def build_request_body(request_data: Any, *, thinking_enabled: bool) -> dict:
+    """Build OpenAI-format request body from Anthropic request."""
+    logger.debug(
+        "ASTRAFLOW_REQUEST: conversion start model={} msgs={}",
+        getattr(request_data, "model", "?"),
+        len(getattr(request_data, "messages", [])),
+    )
+    try:
+        body = build_base_request_body(
+            request_data,
+            reasoning_replay=ReasoningReplayMode.REASONING_CONTENT,
+        )
+    except OpenAIConversionError as exc:
+        raise InvalidRequestError(str(exc)) from exc
+
+    logger.debug(
+        "ASTRAFLOW_REQUEST: conversion done model={} msgs={} tools={}",
+        body.get("model"),
+        len(body.get("messages", [])),
+        len(body.get("tools", [])),
+    )
+    return body

--- a/providers/defaults.py
+++ b/providers/defaults.py
@@ -1,6 +1,8 @@
 """Re-exports default upstream base URLs from the config provider catalog."""
 
 from config.provider_catalog import (
+    ASTRAFLOW_CN_DEFAULT_BASE,
+    ASTRAFLOW_DEFAULT_BASE,
     DEEPSEEK_ANTHROPIC_DEFAULT_BASE,
     DEEPSEEK_DEFAULT_BASE,
     KIMI_DEFAULT_BASE,
@@ -15,6 +17,8 @@ from config.provider_catalog import (
 )
 
 __all__ = (
+    "ASTRAFLOW_CN_DEFAULT_BASE",
+    "ASTRAFLOW_DEFAULT_BASE",
     "DEEPSEEK_ANTHROPIC_DEFAULT_BASE",
     "DEEPSEEK_DEFAULT_BASE",
     "KIMI_DEFAULT_BASE",

--- a/providers/registry.py
+++ b/providers/registry.py
@@ -92,6 +92,18 @@ def _create_zai(config: ProviderConfig, _settings: Settings) -> BaseProvider:
     return ZaiProvider(config)
 
 
+def _create_astraflow(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    from providers.astraflow import AstraflowProvider
+
+    return AstraflowProvider(config)
+
+
+def _create_astraflow_cn(config: ProviderConfig, _settings: Settings) -> BaseProvider:
+    from providers.astraflow import AstraflowCNProvider
+
+    return AstraflowCNProvider(config)
+
+
 PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "nvidia_nim": _create_nvidia_nim,
     "open_router": _create_open_router,
@@ -103,6 +115,8 @@ PROVIDER_FACTORIES: dict[str, ProviderFactory] = {
     "wafer": _create_wafer,
     "opencode": _create_opencode,
     "zai": _create_zai,
+    "astraflow": _create_astraflow,
+    "astraflow_cn": _create_astraflow_cn,
 }
 
 if set(PROVIDER_DESCRIPTORS) != set(SUPPORTED_PROVIDER_IDS) or set(


### PR DESCRIPTION
## Summary

Adds **Astraflow** (by UCloud / 优刻得) as a supported LLM provider — both the **global** and **China** endpoints.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models, so the integration uses the existing `OpenAIChatTransport` base class (same pattern as `kimi`, `opencode`, `zai`) — no new SDK dependency needed.

### Endpoints

| Provider ID    | Endpoint                                   | Env Var                 | Sign-up URL                            |
|----------------|--------------------------------------------|-------------------------|----------------------------------------|
| `astraflow`    | `https://api-us-ca.umodelverse.ai/v1`      | `ASTRAFLOW_API_KEY`     | https://astraflow.ucloud-global.com    |
| `astraflow_cn` | `https://api.modelverse.cn/v1`             | `ASTRAFLOW_CN_API_KEY`  | https://astraflow.ucloud.cn            |

### Usage

Set a model in your `.env`:
```
ASTRAFLOW_API_KEY="your-key-here"
MODEL="astraflow/your-model-name"
```
or for the China endpoint:
```
ASTRAFLOW_CN_API_KEY="your-key-here"
MODEL="astraflow_cn/your-model-name"
```

### Files changed

| File | Change |
|------|--------|
| `config/provider_catalog.py` | Added `ASTRAFLOW_DEFAULT_BASE`, `ASTRAFLOW_CN_DEFAULT_BASE` constants and two `ProviderDescriptor` entries |
| `providers/defaults.py` | Re-exported the two new base URL constants |
| `config/settings.py` | Added `astraflow_api_key`, `astraflow_cn_api_key`, `astraflow_proxy`, `astraflow_cn_proxy` fields |
| `providers/astraflow/__init__.py` | New subpackage init |
| `providers/astraflow/client.py` | `AstraflowProvider` + `AstraflowCNProvider` using `OpenAIChatTransport` |
| `providers/astraflow/request.py` | Request builder (mirrors kimi pattern) |
| `providers/registry.py` | Two factory functions + wired into `PROVIDER_FACTORIES` |
| `.env.example` | New `ASTRAFLOW_API_KEY`, `ASTRAFLOW_CN_API_KEY`, proxy vars, smoke model vars, valid providers comment |
