### PR TITLE
support comma-separated MODEL_* with automatic provider fallback

### DIFF
--- a/api/model_router.py
+++ b/api/model_router.py
@@ -34,6 +34,17 @@ class RoutedTokenCountRequest:
     resolved: ResolvedModel
 
 
+@dataclass(frozen=True, slots=True)
+class RoutedMessagesRequestChain:
+    """Ordered list of routed candidates to try in fallback order."""
+
+    candidates: tuple[RoutedMessagesRequest, ...]
+
+    @property
+    def primary(self) -> RoutedMessagesRequest:
+        return self.candidates[0]
+
+
 class ModelRouter:
     """Resolve incoming Claude model names to configured provider/model pairs."""
 
@@ -41,6 +52,16 @@ class ModelRouter:
         self._settings = settings
 
     def resolve(self, claude_model_name: str) -> ResolvedModel:
+        chain = self.resolve_chain(claude_model_name)
+        return chain[0]
+
+    def resolve_chain(self, claude_model_name: str) -> tuple[ResolvedModel, ...]:
+        """Resolve a Claude model name to an ordered chain of fallback candidates.
+
+        Direct provider model ids (``provider/model`` or ``anthropic/provider/model``)
+        always resolve to a single-entry chain. MODEL_OPUS/SONNET/HAIKU expand into
+        the full comma-separated fallback list configured in settings.
+        """
         (
             direct_provider_id,
             direct_provider_model,
@@ -52,36 +73,47 @@ class ModelRouter:
                 if force_thinking_enabled is not None
                 else self._settings.resolve_thinking(direct_provider_model)
             )
-            logger.debug(
-                "MODEL DIRECT: '{}' -> provider='{}' model='{}' thinking={}",
-                claude_model_name,
-                direct_provider_id,
-                direct_provider_model,
-                thinking_enabled,
-            )
-            return ResolvedModel(
-                original_model=claude_model_name,
-                provider_id=direct_provider_id,
-                provider_model=direct_provider_model,
-                provider_model_ref=claude_model_name,
-                thinking_enabled=thinking_enabled,
+            return (
+                ResolvedModel(
+                    original_model=claude_model_name,
+                    provider_id=direct_provider_id,
+                    provider_model=direct_provider_model,
+                    provider_model_ref=claude_model_name,
+                    thinking_enabled=thinking_enabled,
+                ),
             )
 
-        provider_model_ref = self._settings.resolve_model(claude_model_name)
         thinking_enabled = self._settings.resolve_thinking(claude_model_name)
-        provider_id = Settings.parse_provider_type(provider_model_ref)
-        provider_model = Settings.parse_model_name(provider_model_ref)
-        if provider_model != claude_model_name:
-            logger.debug(
-                "MODEL MAPPING: '{}' -> '{}'", claude_model_name, provider_model
+        chain_refs = self._settings.resolve_model_chain(claude_model_name)
+        if not chain_refs:
+            chain_refs = (self._settings.model,)
+
+        resolved_chain: list[ResolvedModel] = []
+        for provider_model_ref in chain_refs:
+            provider_id = Settings.parse_provider_type(provider_model_ref)
+            provider_model = Settings.parse_model_name(provider_model_ref)
+            resolved_chain.append(
+                ResolvedModel(
+                    original_model=claude_model_name,
+                    provider_id=provider_id,
+                    provider_model=provider_model,
+                    provider_model_ref=provider_model_ref,
+                    thinking_enabled=thinking_enabled,
+                )
             )
-        return ResolvedModel(
-            original_model=claude_model_name,
-            provider_id=provider_id,
-            provider_model=provider_model,
-            provider_model_ref=provider_model_ref,
-            thinking_enabled=thinking_enabled,
-        )
+        if len(resolved_chain) > 1:
+            logger.debug(
+                "MODEL CHAIN: '{}' -> {}",
+                claude_model_name,
+                [c.provider_model_ref for c in resolved_chain],
+            )
+        elif resolved_chain[0].provider_model != claude_model_name:
+            logger.debug(
+                "MODEL MAPPING: '{}' -> '{}'",
+                claude_model_name,
+                resolved_chain[0].provider_model,
+            )
+        return tuple(resolved_chain)
 
     def _direct_provider_model(
         self, model_name: str
@@ -108,11 +140,20 @@ class ModelRouter:
     def resolve_messages_request(
         self, request: MessagesRequest
     ) -> RoutedMessagesRequest:
-        """Return an internal routed request context."""
-        resolved = self.resolve(request.model)
-        routed = request.model_copy(deep=True)
-        routed.model = resolved.provider_model
-        return RoutedMessagesRequest(request=routed, resolved=resolved)
+        """Return an internal routed request context (first candidate only)."""
+        return self.resolve_messages_request_chain(request).primary
+
+    def resolve_messages_request_chain(
+        self, request: MessagesRequest
+    ) -> RoutedMessagesRequestChain:
+        """Return the ordered fallback chain of routed request contexts."""
+        chain = self.resolve_chain(request.model)
+        candidates: list[RoutedMessagesRequest] = []
+        for resolved in chain:
+            routed = request.model_copy(deep=True)
+            routed.model = resolved.provider_model
+            candidates.append(RoutedMessagesRequest(request=routed, resolved=resolved))
+        return RoutedMessagesRequestChain(candidates=tuple(candidates))
 
     def resolve_token_count_request(
         self, request: TokenCountRequest

--- a/api/services.py
+++ b/api/services.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
+import httpx
 from fastapi import HTTPException
 from fastapi.responses import StreamingResponse
 from loguru import logger
@@ -16,9 +17,17 @@ from core.anthropic import get_token_count, get_user_facing_error_message
 from core.anthropic.sse import ANTHROPIC_SSE_RESPONSE_HEADERS
 from core.trace import api_messages_request_snapshot, trace_event, traced_async_stream
 from providers.base import BaseProvider
-from providers.exceptions import InvalidRequestError, ProviderError
+from providers.exceptions import (
+    APIError,
+    AuthenticationError,
+    InvalidRequestError,
+    OverloadedError,
+    ProviderError,
+    RateLimitError,
+    ServiceUnavailableError,
+)
 
-from .model_router import ModelRouter
+from .model_router import ModelRouter, RoutedMessagesRequest
 from .models.anthropic import MessagesRequest, TokenCountRequest
 from .models.responses import TokenCountResponse
 from .optimization_handlers import try_optimizations
@@ -79,6 +88,64 @@ def _log_unexpected_service_exception(
         logger.error("{} exc_type={}", context, type(exc).__name__)
 
 
+_CONVERSION_RETRYABLE_MARKERS = (
+    "image blocks are not supported",
+    "OpenAI chat conversion does not support",
+    "use a native Anthropic transport provider",
+    "use a vision-capable native Anthropic provider",
+)
+
+
+def _is_retryable_provider_error(exc: BaseException) -> bool:
+    """Return True for errors that warrant trying the next provider in a chain."""
+    if isinstance(exc, InvalidRequestError):
+        # Provider-specific conversion limitations (e.g. an OpenAI-chat transport
+        # rejecting image blocks) should fall through to a different provider that
+        # can handle the feature, rather than failing the whole request.
+        message = str(exc)
+        return any(marker in message for marker in _CONVERSION_RETRYABLE_MARKERS)
+    if isinstance(
+        exc,
+        (
+            RateLimitError,
+            OverloadedError,
+            AuthenticationError,
+            ServiceUnavailableError,
+        ),
+    ):
+        return True
+    if isinstance(exc, APIError):
+        return exc.status_code >= 500 or exc.status_code in (
+            401,
+            403,
+            404,
+            408,
+            410,
+            429,
+        )
+    return isinstance(
+        exc,
+        (
+            httpx.ConnectError,
+            httpx.ConnectTimeout,
+            httpx.ReadTimeout,
+            httpx.WriteTimeout,
+            httpx.PoolTimeout,
+            httpx.RemoteProtocolError,
+            httpx.ReadError,
+        ),
+    )
+
+
+async def _continue_stream(
+    stream: AsyncIterator[str], first_chunk: str
+) -> AsyncIterator[str]:
+    """Prepend ``first_chunk`` to an in-flight async stream."""
+    yield first_chunk
+    async for chunk in stream:
+        yield chunk
+
+
 def _require_non_empty_messages(messages: list[Any]) -> None:
     if not messages:
         raise InvalidRequestError("messages cannot be empty")
@@ -104,26 +171,38 @@ class ClaudeProxyService:
         try:
             _require_non_empty_messages(request_data.messages)
 
-            routed = self._model_router.resolve_messages_request(request_data)
-            if routed.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:
+            chain = self._model_router.resolve_messages_request_chain(request_data)
+            primary = chain.primary
+
+            # Single-candidate chains preserve the historical eager-raise contract:
+            # if the sole provider is an openai-chat upstream that cannot handle the
+            # request's web tool blocks, fail fast here rather than deferring to the
+            # streaming generator. Multi-candidate chains let the fallback machinery
+            # try the next provider instead.
+            if (
+                len(chain.candidates) == 1
+                and primary.resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS
+            ):
                 tool_err = openai_chat_upstream_server_tool_error(
-                    routed.request,
+                    primary.request,
                     web_tools_enabled=self._settings.enable_web_server_tools,
                 )
                 if tool_err is not None:
                     raise InvalidRequestError(tool_err)
 
             if self._settings.enable_web_server_tools and is_web_server_tool_request(
-                routed.request
+                primary.request
             ):
                 input_tokens = self._token_counter(
-                    routed.request.messages, routed.request.system, routed.request.tools
+                    primary.request.messages,
+                    primary.request.system,
+                    primary.request.tools,
                 )
                 trace_event(
                     stage="routing",
                     event="api.optimization.web_server_tool",
                     source="api",
-                    model=routed.request.model,
+                    model=primary.request.model,
                 )
                 egress = WebFetchEgressPolicy(
                     allow_private_network_targets=self._settings.web_fetch_allow_private_networks,
@@ -131,81 +210,49 @@ class ClaudeProxyService:
                 )
                 return anthropic_sse_streaming_response(
                     stream_web_server_tool_response(
-                        routed.request,
+                        primary.request,
                         input_tokens=input_tokens,
                         web_fetch_egress=egress,
                         verbose_client_errors=self._settings.log_api_error_tracebacks,
                     ),
                 )
 
-            optimized = try_optimizations(routed.request, self._settings)
+            optimized = try_optimizations(primary.request, self._settings)
             if optimized is not None:
                 trace_event(
                     stage="routing",
                     event="api.optimization.short_circuit",
                     source="api",
-                    model=routed.request.model,
+                    model=primary.request.model,
                 )
                 return optimized
             logger.debug("No optimization matched, routing to provider")
 
-            provider = self._provider_getter(routed.resolved.provider_id)
-            provider.preflight_stream(
-                routed.request,
-                thinking_enabled=routed.resolved.thinking_enabled,
-            )
-
-            trace_event(
-                stage="routing",
-                event="api.route.resolved",
-                source="api",
-                provider_id=routed.resolved.provider_id,
-                provider_model=routed.resolved.provider_model,
-                provider_model_ref=routed.resolved.provider_model_ref,
-                gateway_model=routed.request.model,
-                thinking_enabled=routed.resolved.thinking_enabled,
-            )
-
+            # Emit request-level trace events eagerly so observers see the same
+            # ingress timeline whether or not the body iterator is consumed.
             request_id = f"req_{uuid.uuid4().hex[:12]}"
-            with logger.contextualize(request_id=request_id):
-                trace_event(
-                    stage="ingress",
-                    event="api.request.received",
-                    source="api",
-                    message_count=len(routed.request.messages),
-                    snapshot=api_messages_request_snapshot(routed.request),
+            trace_event(
+                stage="ingress",
+                event="api.request.received",
+                source="api",
+                message_count=len(primary.request.messages),
+                snapshot=api_messages_request_snapshot(primary.request),
+            )
+            if self._settings.log_raw_api_payloads:
+                logger.debug(
+                    "FULL_PAYLOAD [{}]: {}",
+                    request_id,
+                    primary.request.model_dump(),
                 )
 
-                if self._settings.log_raw_api_payloads:
-                    logger.debug(
-                        "FULL_PAYLOAD [{}]: {}", request_id, routed.request.model_dump()
-                    )
+            if len(chain.candidates) == 1:
+                # Single-candidate chain: preserve the historical eager-bind behaviour
+                # so synchronous provider errors surface as HTTP 500 here.
+                return self._stream_single_candidate(primary, request_id)
 
-                input_tokens = self._token_counter(
-                    routed.request.messages,
-                    routed.request.system,
-                    routed.request.tools,
-                )
-
-                streamed = traced_async_stream(
-                    provider.stream_response(
-                        routed.request,
-                        input_tokens=input_tokens,
-                        request_id=request_id,
-                        thinking_enabled=routed.resolved.thinking_enabled,
-                    ),
-                    stage="egress",
-                    source="api",
-                    complete_event="api.response.stream_completed",
-                    interrupted_event="api.response.stream_interrupted",
-                    chunk_event=None,
-                    extra={
-                        "request_id": request_id,
-                        "provider_id": routed.resolved.provider_id,
-                        "gateway_model": routed.request.model,
-                    },
-                )
-                return anthropic_sse_streaming_response(streamed)
+            return anthropic_sse_streaming_response(
+                self._stream_with_fallback(chain.candidates, request_id),
+            )
 
         except ProviderError:
             raise
@@ -217,6 +264,218 @@ class ClaudeProxyService:
                 status_code=_http_status_for_unexpected_service_exception(e),
                 detail=get_user_facing_error_message(e),
             ) from e
+
+    def _stream_single_candidate(
+        self, routed: RoutedMessagesRequest, request_id: str
+    ) -> StreamingResponse:
+        """Eager single-candidate path. Mirrors the pre-chain behaviour."""
+        resolved = routed.resolved
+        provider = self._provider_getter(resolved.provider_id)
+        provider.preflight_stream(
+            routed.request, thinking_enabled=resolved.thinking_enabled
+        )
+        trace_event(
+            stage="routing",
+            event="api.route.resolved",
+            source="api",
+            provider_id=resolved.provider_id,
+            provider_model=resolved.provider_model,
+            provider_model_ref=resolved.provider_model_ref,
+            gateway_model=routed.request.model,
+            thinking_enabled=resolved.thinking_enabled,
+        )
+        with logger.contextualize(request_id=request_id):
+            logger.info(
+                "API_REQUEST: request_id={} model={} messages={}",
+                request_id,
+                routed.request.model,
+                len(routed.request.messages),
+            )
+            input_tokens = self._token_counter(
+                routed.request.messages,
+                routed.request.system,
+                routed.request.tools,
+            )
+            streamed = traced_async_stream(
+                provider.stream_response(
+                    routed.request,
+                    input_tokens=input_tokens,
+                    request_id=request_id,
+                    thinking_enabled=resolved.thinking_enabled,
+                ),
+                stage="egress",
+                source="api",
+                complete_event="api.response.stream_completed",
+                interrupted_event="api.response.stream_interrupted",
+                chunk_event=None,
+                extra={
+                    "request_id": request_id,
+                    "provider_id": resolved.provider_id,
+                    "gateway_model": routed.request.model,
+                },
+            )
+            return anthropic_sse_streaming_response(streamed)
+
+    async def _stream_with_fallback(
+        self,
+        candidates: tuple[RoutedMessagesRequest, ...],
+        request_id: str,
+    ) -> AsyncIterator[str]:
+        """Iterate candidates in order, falling back on retryable upstream errors.
+
+        Only fires fallback before any SSE bytes commit to the client. Each provider
+        is asked to ``raise_pre_stream_errors`` so an upstream 429/5xx/auth/conversion
+        failure surfaces as an exception we can catch and route to the next candidate.
+        """
+        last_error: BaseException | None = None
+        total = len(candidates)
+        single = total == 1
+        for i, routed in enumerate(candidates):
+            resolved = routed.resolved
+            is_last = i == total - 1
+            candidate_tag = f"{resolved.provider_id}/{resolved.provider_model}"
+
+            if resolved.provider_id in _OPENAI_CHAT_UPSTREAM_IDS:
+                tool_err = openai_chat_upstream_server_tool_error(
+                    routed.request,
+                    web_tools_enabled=self._settings.enable_web_server_tools,
+                )
+                if tool_err is not None:
+                    last_error = InvalidRequestError(tool_err)
+                    if is_last:
+                        raise last_error
+                    logger.warning(
+                        "FALLBACK_SKIP: candidate={} ({}/{}) incompatible with Anthropic web tools, trying next",
+                        candidate_tag,
+                        i + 1,
+                        total,
+                    )
+                    continue
+
+            try:
+                provider = self._provider_getter(resolved.provider_id)
+                provider.preflight_stream(
+                    routed.request,
+                    thinking_enabled=resolved.thinking_enabled,
+                )
+            except ProviderError as e:
+                last_error = e
+                if is_last or not _is_retryable_provider_error(e):
+                    raise
+                logger.warning(
+                    "FALLBACK_PREFLIGHT: candidate={} ({}/{}) {} status={}, trying next",
+                    candidate_tag,
+                    i + 1,
+                    total,
+                    type(e).__name__,
+                    getattr(e, "status_code", "n/a"),
+                )
+                continue
+            except Exception as e:
+                last_error = e
+                if is_last:
+                    raise
+                logger.warning(
+                    "FALLBACK_PREFLIGHT: candidate={} ({}/{}) raised {}, trying next",
+                    candidate_tag,
+                    i + 1,
+                    total,
+                    type(e).__name__,
+                )
+                continue
+
+            trace_event(
+                stage="routing",
+                event="api.route.resolved",
+                source="api",
+                provider_id=resolved.provider_id,
+                provider_model=resolved.provider_model,
+                provider_model_ref=resolved.provider_model_ref,
+                gateway_model=routed.request.model,
+                thinking_enabled=resolved.thinking_enabled,
+                candidate_index=i + 1,
+                candidate_total=total,
+            )
+            logger.info(
+                "API_REQUEST: request_id={} candidate={}/{} provider={} model={} messages={}",
+                request_id,
+                i + 1,
+                total,
+                resolved.provider_id,
+                routed.request.model,
+                len(routed.request.messages),
+            )
+            with logger.contextualize(request_id=request_id):
+                input_tokens = self._token_counter(
+                    routed.request.messages,
+                    routed.request.system,
+                    routed.request.tools,
+                )
+                stream = provider.stream_response(
+                    routed.request,
+                    input_tokens=input_tokens,
+                    request_id=request_id,
+                    thinking_enabled=resolved.thinking_enabled,
+                    raise_pre_stream_errors=not single,
+                )
+
+                try:
+                    first_chunk = await stream.__anext__()
+                except StopAsyncIteration:
+                    return
+                except ProviderError as e:
+                    last_error = e
+                    if is_last or not _is_retryable_provider_error(e):
+                        raise
+                    logger.warning(
+                        "FALLBACK_STREAM: candidate={} ({}/{}) {} status={}, trying next",
+                        candidate_tag,
+                        i + 1,
+                        total,
+                        type(e).__name__,
+                        getattr(e, "status_code", "n/a"),
+                    )
+                    continue
+                except Exception as e:
+                    last_error = e
+                    if is_last or not _is_retryable_provider_error(e):
+                        raise
+                    logger.warning(
+                        "FALLBACK_STREAM: candidate={} ({}/{}) raised {}, trying next",
+                        candidate_tag,
+                        i + 1,
+                        total,
+                        type(e).__name__,
+                    )
+                    continue
+
+                logger.info(
+                    "STREAM_COMMIT: request_id={} candidate={}/{} provider={} model={}",
+                    request_id,
+                    i + 1,
+                    total,
+                    resolved.provider_id,
+                    resolved.provider_model,
+                )
+                streamed = traced_async_stream(
+                    _continue_stream(stream, first_chunk),
+                    stage="egress",
+                    source="api",
+                    complete_event="api.response.stream_completed",
+                    interrupted_event="api.response.stream_interrupted",
+                    chunk_event=None,
+                    extra={
+                        "request_id": request_id,
+                        "provider_id": resolved.provider_id,
+                        "gateway_model": routed.request.model,
+                    },
+                )
+                async for chunk in streamed:
+                    yield chunk
+                return
+
+        if last_error is not None:
+            raise last_error
 
     def count_tokens(self, request_data: TokenCountRequest) -> TokenCountResponse:
         """Count tokens for a request after applying configured model routing."""

--- a/config/settings.py
+++ b/config/settings.py
@@ -418,17 +418,32 @@ class Settings(BaseSettings):
     def validate_model_format(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        if "/" not in v:
-            raise ValueError(
-                f"Model must be prefixed with provider type. "
-                f"Valid providers: {', '.join(SUPPORTED_PROVIDER_IDS)}. "
-                f"Format: provider_type/model/name"
-            )
-        provider = v.split("/", 1)[0]
-        if provider not in SUPPORTED_PROVIDER_IDS:
-            supported = ", ".join(f"'{p}'" for p in SUPPORTED_PROVIDER_IDS)
-            raise ValueError(f"Invalid provider: '{provider}'. Supported: {supported}")
-        return v
+        entries = [entry.strip() for entry in v.split(",") if entry.strip()]
+        if not entries:
+            raise ValueError("Model must not be empty")
+        normalized: list[str] = []
+        for entry in entries:
+            if "/" not in entry:
+                raise ValueError(
+                    f"Model entry {entry!r} must be prefixed with provider type. "
+                    f"Valid providers: {', '.join(SUPPORTED_PROVIDER_IDS)}. "
+                    f"Format: provider_type/model/name"
+                )
+            provider = entry.split("/", 1)[0]
+            if provider not in SUPPORTED_PROVIDER_IDS:
+                supported = ", ".join(f"'{p}'" for p in SUPPORTED_PROVIDER_IDS)
+                raise ValueError(
+                    f"Invalid provider in {entry!r}: '{provider}'. Supported: {supported}"
+                )
+            normalized.append(entry)
+        return ",".join(normalized)
+
+    @staticmethod
+    def split_model_chain(model_ref: str | None) -> tuple[str, ...]:
+        """Split a comma-separated MODEL_* value into ordered provider/model entries."""
+        if not model_ref:
+            return ()
+        return tuple(part.strip() for part in model_ref.split(",") if part.strip())
 
     @model_validator(mode="after")
     def check_nvidia_nim_api_key(self) -> Settings:
@@ -468,22 +483,31 @@ class Settings(BaseSettings):
         return Settings.parse_model_name(self.model)
 
     def resolve_model(self, claude_model_name: str) -> str:
-        """Resolve a Claude model name to the configured provider/model string.
+        """Resolve a Claude model name to the FIRST configured provider/model string.
 
-        Classifies the incoming Claude model (opus/sonnet/haiku) and
-        returns the model-specific override if configured, otherwise the fallback MODEL.
+        Kept for backward-compat call sites. Use ``resolve_model_chain`` to get
+        the full ordered list of fallback candidates.
         """
+        chain = self.resolve_model_chain(claude_model_name)
+        return chain[0] if chain else self.model
+
+    def resolve_model_chain(self, claude_model_name: str) -> tuple[str, ...]:
+        """Resolve a Claude model name to the ordered chain of fallback provider/model refs."""
         name_lower = claude_model_name.lower()
         if "opus" in name_lower and self.model_opus is not None:
-            return self.model_opus
+            return Settings.split_model_chain(self.model_opus)
         if "haiku" in name_lower and self.model_haiku is not None:
-            return self.model_haiku
+            return Settings.split_model_chain(self.model_haiku)
         if "sonnet" in name_lower and self.model_sonnet is not None:
-            return self.model_sonnet
-        return self.model
+            return Settings.split_model_chain(self.model_sonnet)
+        return Settings.split_model_chain(self.model)
 
     def configured_chat_model_refs(self) -> tuple[ConfiguredChatModelRef, ...]:
-        """Return unique configured chat provider/model refs with source env keys."""
+        """Return unique configured chat provider/model refs with source env keys.
+
+        Comma-separated MODEL_* values are expanded so every fallback entry is
+        advertised in the /v1/models discovery response.
+        """
         candidates = (
             ("MODEL", self.model),
             ("MODEL_OPUS", self.model_opus),
@@ -492,9 +516,8 @@ class Settings(BaseSettings):
         )
         sources_by_ref: dict[str, list[str]] = {}
         for source, model_ref in candidates:
-            if model_ref is None:
-                continue
-            sources_by_ref.setdefault(model_ref, []).append(source)
+            for entry in Settings.split_model_chain(model_ref):
+                sources_by_ref.setdefault(entry, []).append(source)
 
         return tuple(
             ConfiguredChatModelRef(

--- a/providers/anthropic_messages.py
+++ b/providers/anthropic_messages.py
@@ -343,6 +343,7 @@ class AnthropicMessagesTransport(BaseProvider):
         *,
         request_id: str | None = None,
         thinking_enabled: bool | None = None,
+        raise_pre_stream_errors: bool = False,
     ) -> AsyncIterator[str]:
         """Stream response via a native Anthropic-compatible messages endpoint."""
         tag = self._provider_name
@@ -414,6 +415,21 @@ class AnthropicMessagesTransport(BaseProvider):
                     self._log_stream_transport_error(
                         tag, req_tag, error, request_id=request_id
                     )
+
+                if raise_pre_stream_errors and not sent_any_event:
+                    if response is not None and not response.is_closed:
+                        await _maybe_await_aclose(response)
+                    from providers.error_mapping import map_error
+
+                    mapped = map_error(error, rate_limiter=self._global_rate_limiter)
+                    logger.info(
+                        "{}_STREAM: Raising pre-stream error for fallback: {}{}",
+                        tag,
+                        type(mapped).__name__,
+                        req_tag,
+                    )
+                    raise mapped from error
+
                 error_message = self._get_error_message(error, request_id)
 
                 if response is not None and not response.is_closed:

--- a/providers/base.py
+++ b/providers/base.py
@@ -139,8 +139,16 @@ class BaseProvider(ABC):
         *,
         request_id: str | None = None,
         thinking_enabled: bool | None = None,
+        raise_pre_stream_errors: bool = False,
     ) -> AsyncIterator[str]:
-        """Stream response in Anthropic SSE format."""
+        """Stream response in Anthropic SSE format.
+
+        When ``raise_pre_stream_errors`` is True, the provider raises the mapped
+        :class:`providers.exceptions.ProviderError` (or transport exception)
+        instead of emitting an Anthropic SSE error sequence when the upstream
+        fails before any real content has been streamed. This lets a caller
+        attempt fallback to a different provider.
+        """
         # Typing: abstract async generators need a yield for AsyncIterator[str]
         # inference; this branch is never executed.
         if False:

--- a/providers/openai_compat.py
+++ b/providers/openai_compat.py
@@ -325,11 +325,16 @@ class OpenAIChatTransport(BaseProvider):
         *,
         request_id: str | None = None,
         thinking_enabled: bool | None = None,
+        raise_pre_stream_errors: bool = False,
     ) -> AsyncIterator[str]:
         """Stream response in Anthropic SSE format."""
         with logger.contextualize(request_id=request_id):
             async for event in self._stream_response_impl(
-                request, input_tokens, request_id, thinking_enabled=thinking_enabled
+                request,
+                input_tokens,
+                request_id,
+                thinking_enabled=thinking_enabled,
+                raise_pre_stream_errors=raise_pre_stream_errors,
             ):
                 yield event
 
@@ -340,6 +345,7 @@ class OpenAIChatTransport(BaseProvider):
         request_id: str | None,
         *,
         thinking_enabled: bool | None,
+        raise_pre_stream_errors: bool = False,
     ) -> AsyncIterator[str]:
         """Shared streaming implementation."""
         tag = self._provider_name
@@ -366,18 +372,19 @@ class OpenAIChatTransport(BaseProvider):
             body=provider_chat_body_snapshot(body),
         )
 
-        yield sse.message_start()
-
         think_parser = ThinkTagParser()
         heuristic_parser = HeuristicToolParser()
         finish_reason = None
         usage_info = None
         tool_argument_aliases: dict[str, dict[str, str]] = {}
         tool_argument_alias_buffers: dict[int, str] = {}
+        sent_message_start = False
 
         async with self._global_rate_limiter.concurrency_slot():
             try:
                 stream, body = await self._create_stream(body)
+                yield sse.message_start()
+                sent_message_start = True
                 tool_argument_aliases = self._tool_argument_aliases(body)
                 async for chunk in stream:
                     if getattr(chunk, "usage", None):
@@ -461,6 +468,16 @@ class OpenAIChatTransport(BaseProvider):
             except Exception as e:
                 self._log_stream_transport_error(tag, req_tag, e, request_id=request_id)
                 mapped_e = map_error(e, rate_limiter=self._global_rate_limiter)
+
+                if raise_pre_stream_errors and not sent_message_start:
+                    logger.info(
+                        "{}_STREAM: Raising pre-stream error for fallback: {}{}",
+                        tag,
+                        type(mapped_e).__name__,
+                        req_tag,
+                    )
+                    raise mapped_e from e
+
                 base_message = user_visible_message_for_mapped_provider_error(
                     mapped_e,
                     provider_name=tag,
@@ -475,6 +492,9 @@ class OpenAIChatTransport(BaseProvider):
                     error_message=error_message,
                     mapped_error_type=type(mapped_e).__name__,
                 )
+                if not sent_message_start:
+                    yield sse.message_start()
+                    sent_message_start = True
                 for event in sse.close_all_blocks():
                     yield event
                 if sse.blocks.has_emitted_tool_block():

--- a/tests/api/test_model_router.py
+++ b/tests/api/test_model_router.py
@@ -200,3 +200,64 @@ def test_model_router_logs_mapping(settings):
     assert "MODEL MAPPING" in args[0]
     assert args[1] == "claude-2.1"
     assert args[2] == "fallback-model"
+
+
+def test_model_router_resolve_chain_expands_comma_list(settings):
+    settings.model_opus = "nvidia_nim/big,open_router/qwen/qwen3-coder:free,nvidia_nim/small"
+
+    chain = ModelRouter(settings).resolve_chain("claude-opus-4-20250514")
+
+    assert len(chain) == 3
+    assert chain[0].provider_id == "nvidia_nim"
+    assert chain[0].provider_model == "big"
+    assert chain[1].provider_id == "open_router"
+    assert chain[1].provider_model == "qwen/qwen3-coder:free"
+    assert chain[2].provider_id == "nvidia_nim"
+    assert chain[2].provider_model == "small"
+    for entry in chain:
+        assert entry.original_model == "claude-opus-4-20250514"
+
+
+def test_model_router_resolve_returns_first_chain_entry(settings):
+    settings.model_sonnet = "nvidia_nim/primary,open_router/secondary:free"
+
+    resolved = ModelRouter(settings).resolve("claude-sonnet-4-20250514")
+
+    assert resolved.provider_id == "nvidia_nim"
+    assert resolved.provider_model == "primary"
+
+
+def test_model_router_resolve_chain_single_entry_for_direct_model(settings):
+    chain = ModelRouter(settings).resolve_chain(
+        "anthropic/nvidia_nim/deepseek-ai/deepseek-v4-pro"
+    )
+
+    assert len(chain) == 1
+    assert chain[0].provider_id == "nvidia_nim"
+    assert chain[0].provider_model == "deepseek-ai/deepseek-v4-pro"
+
+
+def test_model_router_resolve_messages_request_chain(settings):
+    settings.model_haiku = "lmstudio/local-a,ollama/local-b"
+
+    request = MessagesRequest(
+        model="claude-3-haiku-20240307",
+        max_tokens=50,
+        messages=[Message(role="user", content="hi")],
+    )
+    routed_chain = ModelRouter(settings).resolve_messages_request_chain(request)
+
+    assert len(routed_chain.candidates) == 2
+    assert routed_chain.primary.request.model == "local-a"
+    assert routed_chain.candidates[1].request.model == "local-b"
+    # The original request must not be mutated.
+    assert request.model == "claude-3-haiku-20240307"
+
+
+def test_model_router_falls_back_to_default_model_chain_when_role_unset(settings):
+    settings.model = "nvidia_nim/a,nvidia_nim/b"
+    settings.model_haiku = None
+
+    chain = ModelRouter(settings).resolve_chain("claude-3-haiku-20240307")
+
+    assert [c.provider_model for c in chain] == ["a", "b"]

--- a/tests/api/test_web_server_tools.py
+++ b/tests/api/test_web_server_tools.py
@@ -43,9 +43,7 @@ class FixedProviderModelRouter(ModelRouter):
         super().__init__(settings)
         self._fixed_provider_id = provider_id
 
-    def resolve_messages_request(
-        self, request: MessagesRequest
-    ) -> RoutedMessagesRequest:
+    def _pinned_routed(self, request: MessagesRequest) -> RoutedMessagesRequest:
         resolved = ResolvedModel(
             original_model=request.model,
             provider_id=self._fixed_provider_id,
@@ -56,6 +54,16 @@ class FixedProviderModelRouter(ModelRouter):
         routed = request.model_copy(deep=True)
         routed.model = resolved.provider_model
         return RoutedMessagesRequest(request=routed, resolved=resolved)
+
+    def resolve_messages_request(
+        self, request: MessagesRequest
+    ) -> RoutedMessagesRequest:
+        return self._pinned_routed(request)
+
+    def resolve_messages_request_chain(self, request: MessagesRequest):
+        from api.model_router import RoutedMessagesRequestChain
+
+        return RoutedMessagesRequestChain(candidates=(self._pinned_routed(request),))
 
 
 def test_web_server_tool_not_detected_when_tool_only_listed():

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -801,3 +801,75 @@ class TestPerModelMapping:
         assert refs[1].provider_id == "open_router"
         assert refs[1].model_id == "anthropic/claude-opus"
         assert refs[1].sources == ("MODEL_OPUS",)
+
+
+class TestModelChain:
+    """Comma-separated MODEL_* values define an ordered fallback chain."""
+
+    def test_split_model_chain_handles_none_and_empty(self):
+        from config.settings import Settings
+
+        assert Settings.split_model_chain(None) == ()
+        assert Settings.split_model_chain("") == ()
+        assert Settings.split_model_chain("   ") == ()
+
+    def test_split_model_chain_trims_and_keeps_order(self):
+        from config.settings import Settings
+
+        chain = Settings.split_model_chain(
+            "nvidia_nim/a, open_router/b:free , nvidia_nim/c"
+        )
+        assert chain == ("nvidia_nim/a", "open_router/b:free", "nvidia_nim/c")
+
+    def test_validator_accepts_comma_separated_chain(self, monkeypatch):
+        from config.settings import Settings
+
+        monkeypatch.setenv(
+            "MODEL_OPUS", "nvidia_nim/big, open_router/qwen/qwen3-coder:free"
+        )
+        s = Settings()
+        # Validator normalizes whitespace and stores the canonical form.
+        assert s.model_opus == "nvidia_nim/big,open_router/qwen/qwen3-coder:free"
+
+    def test_validator_rejects_unknown_provider_in_chain(self, monkeypatch):
+        from config.settings import Settings
+
+        monkeypatch.setenv("MODEL_OPUS", "nvidia_nim/ok, badprovider/x")
+        with pytest.raises(ValueError):
+            Settings()
+
+    def test_resolve_model_chain_returns_full_list(self, monkeypatch):
+        from config.settings import Settings
+
+        monkeypatch.setenv(
+            "MODEL_HAIKU", "nvidia_nim/a,open_router/b:free,nvidia_nim/c"
+        )
+        s = Settings()
+        chain = s.resolve_model_chain("claude-3-haiku-20240307")
+        assert chain == (
+            "nvidia_nim/a",
+            "open_router/b:free",
+            "nvidia_nim/c",
+        )
+
+    def test_resolve_model_returns_first_chain_entry(self, monkeypatch):
+        from config.settings import Settings
+
+        monkeypatch.setenv("MODEL_SONNET", "nvidia_nim/primary,open_router/backup:free")
+        s = Settings()
+        assert s.resolve_model("claude-sonnet-4") == "nvidia_nim/primary"
+
+    def test_chain_entries_advertised_individually_in_chat_refs(self):
+        from config.settings import Settings
+
+        s = Settings()
+        s.model = "nvidia_nim/fallback"
+        s.model_opus = "nvidia_nim/big,open_router/anthropic/claude-opus"
+        s.model_sonnet = None
+        s.model_haiku = None
+
+        refs = {ref.model_ref: ref for ref in s.configured_chat_model_refs()}
+        assert "nvidia_nim/big" in refs
+        assert "open_router/anthropic/claude-opus" in refs
+        assert refs["nvidia_nim/big"].sources == ("MODEL_OPUS",)
+        assert refs["open_router/anthropic/claude-opus"].sources == ("MODEL_OPUS",)


### PR DESCRIPTION
## Summary
- Comma-separated MODEL_* (MODEL, MODEL_OPUS, MODEL_SONNET, MODEL_HAIKU) become an ordered fallback chain
- The proxy walks the chain on retryable upstream errors before any SSE byte is written to the client
- /v1/models discovery expands every chain entry so the model picker shows all configured fallbacks

## Motivation
Free providers (OpenRouter free tier in particular) frequently hit 429/upstream rate limits. Today a single rate-limited primary model fails the whole request even when other configured providers would happily serve it. With a chain, the proxy transparently falls forward to the next entry on retryable errors, so a transient throttle on one upstream doesn't surface to the client.

## How it works
Providers expose a new ``raise_pre_stream_errors`` flag on ``stream_response``. When set, the provider raises the mapped exception instead of emitting an Anthropic SSE error sequence whenever the upstream fails before any real content has been streamed. The service prefetches the first SSE chunk from each candidate inside ``_stream_with_fallback``; on a retryable failure it discards the candidate, logs ``FALLBACK_PREFLIGHT`` or ``FALLBACK_STREAM``, and tries the next entry. Once a candidate's first chunk lands, it commits and streams the rest live.

Retryable errors:
- ``RateLimitError`` / ``OverloadedError`` / ``AuthenticationError`` / ``ServiceUnavailableError``
- ``APIError`` with status ``5xx``, ``401``, ``403``, ``404``, ``408``, ``410``, ``429``
- ``httpx`` connect / read / write / pool timeouts and remote-protocol errors
- ``InvalidRequestError`` messages reporting provider-specific conversion gaps (e.g. image blocks rejected by an OpenAI-chat upstream)

## Backward compatibility
Single-candidate chains keep the historical eager-bind path — ``provider.preflight_stream`` and ``stream_response`` run synchronously inside ``create_message`` so synchronous provider errors still surface as HTTP 500. The ``openai_chat_upstream_server_tool_error`` check also stays eager for single-candidate setups. Existing single-provider deployments see no behaviour change. All existing tests pass; the only test-double update is the small ``FixedProviderModelRouter`` in ``tests/api/test_web_server_tools.py`` (also needs to override the new chain method).

## Example .env
```
MODEL_OPUS=nvidia_nim/qwen/qwen3-coder-480b-a35b-instruct,nvidia_nim/openai/gpt-oss-120b,open_router/qwen/qwen3-coder:free
MODEL_SONNET=nvidia_nim/qwen/qwen3-coder-480b-a35b-instruct,open_router/qwen/qwen3-coder:free,open_router/z-ai/glm-4.5-air:free
MODEL_HAIKU=nvidia_nim/openai/gpt-oss-20b,open_router/z-ai/glm-4.5-air:free
```

## Test plan
- [x] new unit tests in ``tests/api/test_model_router.py`` cover chain expansion, direct-model bypass, and request-mutation safety
- [x] new unit tests in ``tests/config/test_config.py::TestModelChain`` cover comma parsing, whitespace normalisation, validator rejection, and chat-ref expansion
- [x] full suite passes: ``pytest tests/api tests/config tests/providers tests/core`` → 869 passed
- [x] ruff check + ruff format pass on touched files