### PR TITLE
return single JSON when stream is omitted or set false

### DIFF
--- a/api/models/anthropic.py
+++ b/api/models/anthropic.py
@@ -140,7 +140,8 @@ class MessagesRequest(BaseModel):
     messages: list[Message]
     system: str | list[SystemContent] | None = None
     stop_sequences: list[str] | None = None
-    stream: bool | None = True
+    # Matches Anthropic API contract: omit -> non-streaming JSON, explicit True -> SSE.
+    stream: bool | None = None
     temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None

--- a/api/routes.py
+++ b/api/routes.py
@@ -169,8 +169,16 @@ async def create_message(
     service: ClaudeProxyService = Depends(get_proxy_service),
     _auth=Depends(require_api_key),
 ):
-    """Create a message (always streaming)."""
-    return service.create_message(request_data)
+    """Create a message.
+
+    Streams SSE when ``stream: true`` is explicitly set; otherwise returns a
+    single JSON Messages response. Matches Anthropic API contract so clients
+    using the official SDK or LiteLLM/OpenAI adapters that omit ``stream`` get
+    back a JSON body instead of a partial SSE stream they can't decode.
+    """
+    if request_data.stream is True:
+        return service.create_message(request_data)
+    return await service.create_message_non_streaming(request_data)
 
 
 @router.api_route("/v1/messages", methods=["HEAD", "OPTIONS"])

--- a/api/services.py
+++ b/api/services.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
+import json
 import traceback
 import uuid
 from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 from fastapi import HTTPException
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 
 from config.settings import Settings
@@ -79,6 +81,126 @@ def _log_unexpected_service_exception(
         logger.error("{} exc_type={}", context, type(exc).__name__)
 
 
+def _parse_sse_event(raw: str) -> tuple[str | None, dict | None]:
+    """Parse one SSE event chunk into ``(event_name, data_dict)``.
+
+    Returns ``(None, None)`` if the chunk is malformed or has no JSON payload.
+    """
+    event_name: str | None = None
+    data_str: str | None = None
+    for line in raw.splitlines():
+        if line.startswith("event:"):
+            event_name = line[6:].strip()
+        elif line.startswith("data:"):
+            piece = line[5:].strip()
+            data_str = piece if data_str is None else data_str + piece
+    if not event_name or data_str is None:
+        return None, None
+    try:
+        return event_name, json.loads(data_str)
+    except json.JSONDecodeError:
+        return event_name, None
+
+
+async def aggregate_sse_to_anthropic_response(
+    sse_stream: AsyncIterator[str],
+) -> dict[str, Any]:
+    """Consume an Anthropic SSE stream and assemble a single Messages JSON response.
+
+    Used to satisfy ``stream: false`` requests when the upstream gateway always
+    streams. Builds content blocks (text / tool_use / thinking) from the
+    block_start/delta/stop events and merges usage from message_delta.
+    """
+    message: dict[str, Any] = {
+        "id": f"msg_{uuid.uuid4().hex[:24]}",
+        "type": "message",
+        "role": "assistant",
+        "model": "",
+        "content": [],
+        "stop_reason": None,
+        "stop_sequence": None,
+        "usage": {"input_tokens": 0, "output_tokens": 0},
+    }
+    blocks: dict[int, dict[str, Any]] = {}
+    tool_arg_buffers: dict[int, list[str]] = {}
+    buffer = ""
+    async for chunk in sse_stream:
+        buffer += chunk
+        while "\n\n" in buffer:
+            event_text, buffer = buffer.split("\n\n", 1)
+            name, data = _parse_sse_event(event_text)
+            if name is None or data is None:
+                continue
+            if name == "message_start":
+                msg = data.get("message", {})
+                if isinstance(msg, dict):
+                    for k in ("id", "model"):
+                        if msg.get(k):
+                            message[k] = msg[k]
+                    usage = msg.get("usage")
+                    if isinstance(usage, dict):
+                        message["usage"]["input_tokens"] = usage.get(
+                            "input_tokens", message["usage"]["input_tokens"]
+                        )
+                        message["usage"]["output_tokens"] = usage.get(
+                            "output_tokens", message["usage"]["output_tokens"]
+                        )
+            elif name == "content_block_start":
+                idx = data.get("index", 0)
+                block = data.get("content_block", {})
+                if isinstance(block, dict):
+                    blocks[idx] = dict(block)
+                    if block.get("type") == "tool_use":
+                        tool_arg_buffers[idx] = []
+                        blocks[idx].setdefault("input", {})
+                    elif block.get("type") == "thinking":
+                        blocks[idx].setdefault("thinking", "")
+                    else:
+                        blocks[idx].setdefault("text", "")
+            elif name == "content_block_delta":
+                idx = data.get("index", 0)
+                delta = data.get("delta", {})
+                if not isinstance(delta, dict):
+                    continue
+                block = blocks.setdefault(idx, {"type": "text", "text": ""})
+                dtype = delta.get("type")
+                if dtype == "text_delta":
+                    block["text"] = block.get("text", "") + delta.get("text", "")
+                elif dtype == "thinking_delta":
+                    block["thinking"] = block.get("thinking", "") + delta.get(
+                        "thinking", ""
+                    )
+                elif dtype == "input_json_delta":
+                    tool_arg_buffers.setdefault(idx, []).append(
+                        delta.get("partial_json", "")
+                    )
+            elif name == "content_block_stop":
+                idx = data.get("index", 0)
+                if idx in tool_arg_buffers:
+                    joined = "".join(tool_arg_buffers.pop(idx))
+                    if joined:
+                        try:
+                            blocks[idx]["input"] = json.loads(joined)
+                        except json.JSONDecodeError:
+                            blocks[idx]["input"] = {"_raw": joined}
+            elif name == "message_delta":
+                delta = data.get("delta", {})
+                if isinstance(delta, dict):
+                    if "stop_reason" in delta:
+                        message["stop_reason"] = delta["stop_reason"]
+                    if "stop_sequence" in delta:
+                        message["stop_sequence"] = delta["stop_sequence"]
+                usage = data.get("usage", {})
+                if isinstance(usage, dict) and "output_tokens" in usage:
+                    message["usage"]["output_tokens"] = usage["output_tokens"]
+            elif name == "message_stop":
+                pass
+    message["content"] = [blocks[k] for k in sorted(blocks.keys())]
+    if message["stop_reason"] is None:
+        message["stop_reason"] = "end_turn"
+    return message
+
+
 def _require_non_empty_messages(messages: list[Any]) -> None:
     if not messages:
         raise InvalidRequestError("messages cannot be empty")
@@ -98,6 +220,29 @@ class ClaudeProxyService:
         self._provider_getter = provider_getter
         self._model_router = model_router or ModelRouter(settings)
         self._token_counter = token_counter
+
+    async def create_message_non_streaming(
+        self, request_data: MessagesRequest
+    ) -> JSONResponse:
+        """Aggregate the streaming response and return a single Messages JSON.
+
+        Used to satisfy clients that send ``stream: false`` (or omit ``stream``,
+        which Anthropic treats as non-streaming). The gateway always produces an
+        SSE stream internally; this method consumes it and returns the assembled
+        Anthropic Messages object as a JSON response.
+        """
+        streaming = self.create_message(request_data)
+        if not isinstance(streaming, StreamingResponse):
+            return streaming  # already a non-streaming response (e.g. optimization short-circuit)
+        body = streaming.body_iterator
+        try:
+            message = await aggregate_sse_to_anthropic_response(body)
+        finally:
+            close = getattr(body, "aclose", None)
+            if close is not None:
+                with contextlib.suppress(Exception):
+                    await close()
+        return JSONResponse(message)
 
     def create_message(self, request_data: MessagesRequest) -> object:
         """Create a message response or streaming response."""

--- a/core/anthropic/native_messages_request.py
+++ b/core/anthropic/native_messages_request.py
@@ -241,6 +241,10 @@ def build_base_native_anthropic_request_body(
             thinking_enabled=thinking_enabled,
         )
 
+    # Native streaming transports always consume an SSE stream upstream. The
+    # gateway aggregates the events back into JSON for non-streaming clients.
+    body["stream"] = True
+
     return body
 
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -95,6 +95,39 @@ def test_create_message_stream(client: TestClient):
     assert b"message_start" in content or b"event:" in content
 
 
+def test_create_message_non_streaming_returns_json(client: TestClient):
+    """Omitting stream (Anthropic default) returns a single JSON Messages object."""
+    payload = {
+        "model": "claude-3-sonnet",
+        "messages": [{"role": "user", "content": "Hi"}],
+        "max_tokens": 100,
+    }
+    response = client.post("/v1/messages", json=payload)
+    assert response.status_code == 200
+    assert "application/json" in response.headers.get("content-type", "")
+    body = response.json()
+    assert body["type"] == "message"
+    assert body["role"] == "assistant"
+    assert isinstance(body["content"], list)
+    assert "usage" in body
+    assert "stop_reason" in body
+
+
+def test_create_message_explicit_stream_false_returns_json(client: TestClient):
+    """Explicit stream:false also routes through the non-streaming path."""
+    payload = {
+        "model": "claude-3-sonnet",
+        "messages": [{"role": "user", "content": "Hi"}],
+        "max_tokens": 100,
+        "stream": False,
+    }
+    response = client.post("/v1/messages", json=payload)
+    assert response.status_code == 200
+    assert "application/json" in response.headers.get("content-type", "")
+    body = response.json()
+    assert body["type"] == "message"
+
+
 def test_model_mapping(client: TestClient):
     # Test Haiku mapping
     _stream_response_calls.clear()
@@ -246,3 +279,86 @@ def test_stop_endpoint_no_handler_no_cli_503(client: TestClient):
         delattr(app.state, "cli_manager")
     response = client.post("/stop")
     assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_aggregate_sse_to_anthropic_response_assembles_message():
+    """Aggregator stitches an SSE stream into a single Messages JSON object."""
+    from api.services import aggregate_sse_to_anthropic_response
+
+    chunks = [
+        'event: message_start\n'
+        'data: {"type":"message_start","message":{"id":"msg_abc","type":"message",'
+        '"role":"assistant","content":[],"model":"qwen/qwen3-coder","stop_reason":null,'
+        '"stop_sequence":null,"usage":{"input_tokens":7,"output_tokens":1}}}\n\n',
+        'event: content_block_start\n'
+        'data: {"type":"content_block_start","index":0,'
+        '"content_block":{"type":"text","text":""}}\n\n',
+        'event: content_block_delta\n'
+        'data: {"type":"content_block_delta","index":0,'
+        '"delta":{"type":"text_delta","text":"Hello"}}\n\n',
+        'event: content_block_delta\n'
+        'data: {"type":"content_block_delta","index":0,'
+        '"delta":{"type":"text_delta","text":" world"}}\n\n',
+        'event: content_block_stop\n'
+        'data: {"type":"content_block_stop","index":0}\n\n',
+        'event: message_delta\n'
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn",'
+        '"stop_sequence":null},"usage":{"output_tokens":6}}\n\n',
+        'event: message_stop\n'
+        'data: {"type":"message_stop"}\n\n',
+    ]
+
+    async def fake_stream():
+        for c in chunks:
+            yield c
+
+    msg = await aggregate_sse_to_anthropic_response(fake_stream())
+
+    assert msg["id"] == "msg_abc"
+    assert msg["type"] == "message"
+    assert msg["role"] == "assistant"
+    assert msg["model"] == "qwen/qwen3-coder"
+    assert msg["stop_reason"] == "end_turn"
+    assert msg["content"] == [{"type": "text", "text": "Hello world"}]
+    assert msg["usage"] == {"input_tokens": 7, "output_tokens": 6}
+
+
+@pytest.mark.asyncio
+async def test_aggregate_sse_to_anthropic_response_assembles_tool_use():
+    """Tool-use blocks merge their incremental input_json_delta payloads."""
+    from api.services import aggregate_sse_to_anthropic_response
+
+    chunks = [
+        'event: message_start\n'
+        'data: {"type":"message_start","message":{"id":"msg_t","type":"message",'
+        '"role":"assistant","content":[],"model":"m","stop_reason":null,'
+        '"stop_sequence":null,"usage":{"input_tokens":2,"output_tokens":1}}}\n\n',
+        'event: content_block_start\n'
+        'data: {"type":"content_block_start","index":0,'
+        '"content_block":{"type":"tool_use","id":"toolu_1","name":"echo"}}\n\n',
+        'event: content_block_delta\n'
+        'data: {"type":"content_block_delta","index":0,'
+        '"delta":{"type":"input_json_delta","partial_json":"{\\"q\\":"}}\n\n',
+        'event: content_block_delta\n'
+        'data: {"type":"content_block_delta","index":0,'
+        '"delta":{"type":"input_json_delta","partial_json":"\\"hi\\"}"}}\n\n',
+        'event: content_block_stop\n'
+        'data: {"type":"content_block_stop","index":0}\n\n',
+        'event: message_delta\n'
+        'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},'
+        '"usage":{"output_tokens":4}}\n\n',
+        'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]
+
+    async def fake_stream():
+        for c in chunks:
+            yield c
+
+    msg = await aggregate_sse_to_anthropic_response(fake_stream())
+
+    assert msg["stop_reason"] == "tool_use"
+    assert msg["content"][0]["type"] == "tool_use"
+    assert msg["content"][0]["name"] == "echo"
+    assert msg["content"][0]["id"] == "toolu_1"
+    assert msg["content"][0]["input"] == {"q": "hi"}


### PR DESCRIPTION
## Summary
- Match the Anthropic Messages API contract: omitting ``stream`` returns a single JSON Messages object, ``stream: true`` returns SSE
- Service-side aggregator stitches the internal SSE stream back into a JSON Messages response (text, tool_use, thinking, usage)
- Unblocks LiteLLM's anthropic adapter, the OpenAI SDK's anthropic shim, browser-use, and any client that POSTs without ``stream: true``

## Background
Real Anthropic's ``POST /v1/messages`` defaults to non-streaming JSON. Free Claude Code was unconditionally returning ``text/event-stream`` because ``MessagesRequest.stream`` defaulted to ``True`` and the service always wrapped the response in ``StreamingResponse``. Clients that omit ``stream`` (the default for most SDKs) got a JSON-decode failure on the SSE body.

Reproduction before this PR:
```bash
curl -s http://localhost:8082/v1/messages \
  -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet-4-20250514","max_tokens":10,
       "messages":[{"role":"user","content":"hi"}]}'
# -> event: message_start ... (SSE)
```

After:
```bash
# same request without stream:true
# -> Content-Type: application/json
# -> {"id":"msg_...","type":"message","role":"assistant","content":[...],"usage":...}
```

## What changed
- ``MessagesRequest.stream`` defaults to ``None`` so the route can distinguish ``omitted`` from ``explicit true``.
- ``POST /v1/messages`` dispatches: ``stream: true`` keeps the existing SSE path, anything else goes through ``create_message_non_streaming``.
- ``ClaudeProxyService.create_message_non_streaming`` reuses the existing streaming pipeline and pipes the body through ``aggregate_sse_to_anthropic_response``, which assembles a Messages JSON object from the SSE events.
- ``build_base_native_anthropic_request_body`` now pins ``stream: True`` on the upstream body for native Anthropic providers (wafer, deepseek, etc) so the gateway still consumes SSE upstream regardless of what the client asked for.

## Aggregator coverage
- ``message_start`` carries the initial envelope (id, model, input usage)
- ``content_block_start`` / ``content_block_delta`` / ``content_block_stop`` produce text, tool_use (with ``input_json_delta`` reassembled into a JSON object), and thinking blocks
- ``message_delta`` updates ``stop_reason`` / ``stop_sequence`` and merges output_tokens
- ``message_stop`` closes the message

## Test plan
- [x] new ``test_create_message_non_streaming_returns_json`` and ``test_create_message_explicit_stream_false_returns_json`` end-to-end via TestClient
- [x] new aggregator unit tests for text and tool_use paths
- [x] full suite passes: ``pytest tests/api tests/config tests/providers tests/core`` → 861 passed
- [x] ruff check + ruff format pass on touched files
- [x] manual verification: ``curl`` with omitted ``stream`` returns ``application/json``; with ``stream: true`` returns ``text/event-stream``; works against the LiteLLM anthropic adapter (browser-use driving a chrome agent)