### PR TITLE
admin: preserve repo .env values on first apply

### DIFF
--- a/api/admin_config.py
+++ b/api/admin_config.py
@@ -958,9 +958,10 @@ def _target_values_with_updates(updates: Mapping[str, Any]) -> dict[str, str]:
             {key: val for key, val in managed_values.items() if key in values}
         )
     else:
-        for key, entry in state.items():
-            if entry["source"] in {"repo_env", "template", "default"}:
-                values[key] = str(entry["value"])
+        repo_values = _dotenv_values_from_file(repo_env_path())
+        for key, val in repo_values.items():
+            if key in values:
+                values[key] = val
 
     for key, value in updates.items():
         field = FIELD_BY_KEY.get(key)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "free-claude-code",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "free-claude-code",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Preserve repository .env values during first admin apply to avoid dropping secrets. This fixes a migration bug where the admin managed env on first apply could lose repo .env secret values (e.g., DEEPSEEK_API_KEY). The change seeds the first managed write explicitly from the repository .env file